### PR TITLE
feat: Add config test command and document 1Password integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,41 @@ make build
 
 Your token is stored securely in macOS Keychain.
 
+### Verify Setup
+
+```bash
+slack-cli config test
+```
+
+This tests your token against the Slack API and shows workspace/user info.
+
 ### Alternative: Environment Variable
 
 ```bash
 export SLACK_API_TOKEN=xoxb-your-token-here
 ```
+
+### Alternative: 1Password Integration
+
+Use a shell function to lazy-load your token from 1Password on first use:
+
+```bash
+# Add to ~/.zshrc or ~/.bashrc
+slack() {
+  if [[ -z "$SLACK_API_TOKEN" ]]; then
+    export SLACK_API_TOKEN="$(op read 'op://Personal/slack-cli/api_token')"
+  fi
+  command slack-cli "$@"
+}
+```
+
+Or create an alias that always fetches fresh:
+
+```bash
+alias slack='SLACK_API_TOKEN="$(op read '\''op://Personal/slack-cli/api_token'\'')" slack-cli'
+```
+
+Replace `op://Personal/slack-cli/api_token` with your 1Password secret reference.
 
 ### Required Scopes
 
@@ -233,6 +263,9 @@ slack-cli config set-token xoxb-your-token-here
 # Show current config status
 slack-cli config show
 
+# Test authentication
+slack-cli config test
+
 # Delete stored token
 slack-cli config delete-token
 ```
@@ -243,6 +276,7 @@ slack-cli config delete-token
 |---------|-------|-------------|
 | `set-token [token]` | | Set API token (prompts if not provided) |
 | `show` | | Show current configuration status |
+| `test` | | Test Slack authentication |
 | `delete-token` | `--force` | Delete stored API token (prompts for confirmation) |
 
 ### Output Formats

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -519,6 +519,30 @@ func (c *Client) GetTeamInfo() (*Team, error) {
 	return &result.Team, nil
 }
 
+// AuthTestResponse represents the response from auth.test API
+type AuthTestResponse struct {
+	Team   string `json:"team"`
+	User   string `json:"user"`
+	TeamID string `json:"team_id"`
+	UserID string `json:"user_id"`
+	BotID  string `json:"bot_id,omitempty"`
+}
+
+// AuthTest verifies authentication and returns identity info
+func (c *Client) AuthTest() (*AuthTestResponse, error) {
+	body, err := c.post("auth.test", map[string]interface{}{})
+	if err != nil {
+		return nil, err
+	}
+
+	var result AuthTestResponse
+	if err := json.Unmarshal(body, &result); err != nil {
+		return nil, err
+	}
+
+	return &result, nil
+}
+
 // CreateChannel creates a new channel
 func (c *Client) CreateChannel(name string, isPrivate bool) (*Channel, error) {
 	data := map[string]interface{}{

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -14,6 +14,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(newSetTokenCmd())
 	cmd.AddCommand(newDeleteTokenCmd())
 	cmd.AddCommand(newShowCmd())
+	cmd.AddCommand(newTestCmd())
 
 	return cmd
 }

--- a/internal/cmd/config/test.go
+++ b/internal/cmd/config/test.go
@@ -1,0 +1,50 @@
+package config
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/piekstra/slack-cli/internal/client"
+	"github.com/piekstra/slack-cli/internal/output"
+)
+
+type testOptions struct{}
+
+func newTestCmd() *cobra.Command {
+	opts := &testOptions{}
+
+	return &cobra.Command{
+		Use:   "test",
+		Short: "Test Slack authentication",
+		Long:  "Verify that the configured API token authenticates successfully with Slack.",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runTest(opts, nil)
+		},
+	}
+}
+
+func runTest(opts *testOptions, c *client.Client) error {
+	output.Println("Testing Slack authentication...")
+
+	if c == nil {
+		var err error
+		c, err = client.New()
+		if err != nil {
+			return err
+		}
+	}
+
+	info, err := c.AuthTest()
+	if err != nil {
+		output.Println("Authentication failed")
+		return err
+	}
+
+	output.Println("Authentication successful")
+	output.KeyValue("Workspace", info.Team)
+	output.KeyValue("User", info.User)
+	if info.BotID != "" {
+		output.KeyValue("Bot ID", info.BotID)
+	}
+
+	return nil
+}

--- a/internal/cmd/config/test_test.go
+++ b/internal/cmd/config/test_test.go
@@ -1,0 +1,182 @@
+package config
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/piekstra/slack-cli/internal/client"
+	"github.com/piekstra/slack-cli/internal/keychain"
+)
+
+func TestRunTest_Success(t *testing.T) {
+	tests := []struct {
+		name     string
+		response map[string]interface{}
+	}{
+		{
+			name: "bot token with bot_id",
+			response: map[string]interface{}{
+				"ok":      true,
+				"team":    "Test Workspace",
+				"user":    "test-bot",
+				"bot_id":  "B123456",
+				"team_id": "T123456",
+				"user_id": "U123456",
+			},
+		},
+		{
+			name: "user token without bot_id",
+			response: map[string]interface{}{
+				"ok":      true,
+				"team":    "Another Workspace",
+				"user":    "human-user",
+				"team_id": "T789",
+				"user_id": "U789",
+			},
+		},
+		{
+			name: "minimal response",
+			response: map[string]interface{}{
+				"ok":   true,
+				"team": "Minimal",
+				"user": "bot",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, "/auth.test", r.URL.Path)
+				assert.Equal(t, "POST", r.Method)
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			c := client.NewWithConfig(server.URL, "test-token", nil)
+			opts := &testOptions{}
+
+			err := runTest(opts, c)
+			require.NoError(t, err)
+		})
+	}
+}
+
+func TestRunTest_AuthErrors(t *testing.T) {
+	tests := []struct {
+		name            string
+		response        map[string]interface{}
+		wantErrContains string
+	}{
+		{
+			name: "invalid_auth",
+			response: map[string]interface{}{
+				"ok":    false,
+				"error": "invalid_auth",
+			},
+			wantErrContains: "invalid_auth",
+		},
+		{
+			name: "token_revoked",
+			response: map[string]interface{}{
+				"ok":    false,
+				"error": "token_revoked",
+			},
+			wantErrContains: "token_revoked",
+		},
+		{
+			name: "account_inactive",
+			response: map[string]interface{}{
+				"ok":    false,
+				"error": "account_inactive",
+			},
+			wantErrContains: "account_inactive",
+		},
+		{
+			name: "missing_scope",
+			response: map[string]interface{}{
+				"ok":    false,
+				"error": "missing_scope",
+			},
+			wantErrContains: "missing_scope",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_ = json.NewEncoder(w).Encode(tt.response)
+			}))
+			defer server.Close()
+
+			c := client.NewWithConfig(server.URL, "bad-token", nil)
+			opts := &testOptions{}
+
+			err := runTest(opts, c)
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErrContains)
+		})
+	}
+}
+
+func TestRunTest_NetworkErrors(t *testing.T) {
+	t.Run("server unavailable", func(t *testing.T) {
+		// Use a port that's not listening
+		c := client.NewWithConfig("http://localhost:59999", "test-token", nil)
+		opts := &testOptions{}
+
+		err := runTest(opts, c)
+		require.Error(t, err)
+	})
+
+	t.Run("server returns 500", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+		}))
+		defer server.Close()
+
+		c := client.NewWithConfig(server.URL, "test-token", nil)
+		opts := &testOptions{}
+
+		err := runTest(opts, c)
+		require.Error(t, err)
+	})
+
+	t.Run("server returns invalid JSON", func(t *testing.T) {
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			_, _ = w.Write([]byte("not json"))
+		}))
+		defer server.Close()
+
+		c := client.NewWithConfig(server.URL, "test-token", nil)
+		opts := &testOptions{}
+
+		err := runTest(opts, c)
+		require.Error(t, err)
+	})
+}
+
+func TestRunTest_NoTokenConfigured(t *testing.T) {
+	if keychain.IsSecureStorage() {
+		t.Skip("Skipping on macOS - keychain may have stored token")
+	}
+
+	// Use temp dir with no token set
+	tempDir := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tempDir)
+	t.Setenv("SLACK_API_TOKEN", "") // Ensure env var is empty
+
+	opts := &testOptions{}
+
+	// Pass nil client to trigger token lookup
+	err := runTest(opts, nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no API token")
+}


### PR DESCRIPTION
## Summary

- Add `slack-cli config test` command to verify Slack authentication
- Document 1Password integration via shell functions in README
- Add `AuthTest()` method to client for auth.test API

## Changes

### New Command: `config test`

```bash
$ slack-cli config test
Testing Slack authentication...
Authentication successful
Workspace:    My Workspace
User:         my-bot
Bot ID:       B123456
```

### Documentation

Added to README:
- "Verify Setup" section showing `config test` usage
- "1Password Integration" section with shell function examples for lazy-loading tokens

## Test plan

- [x] All existing tests pass (`make test`)
- [x] Lint passes (`make lint`)
- [x] New tests cover success cases, auth errors, network errors
- [ ] Manual test: `slack-cli config test` with valid token
- [ ] Manual test: `slack-cli config test` with invalid token

Closes #22

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)