### PR TITLE
fix: Handle token source correctly in config commands

### DIFF
--- a/internal/cmd/config/delete_token.go
+++ b/internal/cmd/config/delete_token.go
@@ -35,6 +35,15 @@ func newDeleteTokenCmd() *cobra.Command {
 }
 
 func runDeleteToken(opts *deleteTokenOptions) error {
+	// Check if there's actually a stored token to delete
+	if !keychain.HasStoredToken() {
+		output.Println("No token stored in keychain/config file to delete.")
+		if os.Getenv("SLACK_API_TOKEN") != "" {
+			output.Println("Note: Token is set via SLACK_API_TOKEN environment variable.")
+		}
+		return nil
+	}
+
 	// Prompt for confirmation unless --force
 	if !opts.force {
 		reader := opts.stdin

--- a/internal/cmd/config/show.go
+++ b/internal/cmd/config/show.go
@@ -34,11 +34,8 @@ func runShow(opts *showOptions) error {
 	// Mask the token for display
 	masked := token[:8] + strings.Repeat("*", len(token)-12) + token[len(token)-4:]
 
-	if keychain.IsSecureStorage() {
-		output.Printf("API Token: %s (from Keychain)\n", masked)
-	} else {
-		output.Printf("API Token: %s (from config file)\n", masked)
-	}
+	source := keychain.GetTokenSource()
+	output.Printf("API Token: %s (from %s)\n", masked, source)
 
 	return nil
 }

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -46,6 +46,26 @@ func IsSecureStorage() bool {
 	return runtime.GOOS == "darwin"
 }
 
+// HasStoredToken returns true if a token is stored in keychain/config (not env var)
+func HasStoredToken() bool {
+	token, err := getCredential(apiTokenKey)
+	return err == nil && token != ""
+}
+
+// GetTokenSource returns where the current token is stored
+func GetTokenSource() string {
+	if token, err := getCredential(apiTokenKey); err == nil && token != "" {
+		if runtime.GOOS == "darwin" {
+			return "Keychain"
+		}
+		return "config file"
+	}
+	if os.Getenv("SLACK_API_TOKEN") != "" {
+		return "environment variable"
+	}
+	return ""
+}
+
 // --- Platform-specific implementations ---
 
 func getCredential(key string) (string, error) {


### PR DESCRIPTION
## Summary
- `config show` now correctly reports the actual token source (Keychain, config file, or environment variable)
- `config delete-token` gracefully handles case where token is from env var (no keychain entry to delete)
- Added `HasStoredToken()` and `GetTokenSource()` helper functions

## Root Cause
The `show` command used `IsSecureStorage()` which just checks if running on macOS, not where the token actually came from. When the token was from `SLACK_API_TOKEN` env var, it incorrectly said "(from Keychain)" and delete would fail with exit status 44.

## Test plan
- [x] Unit tests pass (`make test`)
- [x] `config show` with env var only → shows "(from environment variable)"
- [x] `config delete-token` with env var only → graceful message, no error
- [x] `config set-token` → `show` → "(from Keychain)" → `delete-token` → works

Fixes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)