### PR TITLE
fix: Add helpful error for unarchive limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,16 @@ Commands have convenient aliases:
 | `NO_COLOR` | Disable colored output when set |
 | `XDG_CONFIG_HOME` | Custom config directory (default: `~/.config`) |
 
+## Known Limitations
+
+### Unarchiving Channels
+
+Bot tokens (`xoxb-`) cannot unarchive channels due to a [Slack API limitation](https://api.slack.com/methods/conversations.unarchive). When a channel is archived, the bot is automatically removed from it, and bot tokens require membership to unarchive.
+
+**Workarounds:**
+- Unarchive channels via the Slack UI
+- Use a user token (`xoxp-`) instead of a bot token
+
 ## License
 
 MIT

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -819,8 +819,8 @@ func TestClient_ListChannels_PaginationWithLimit(t *testing.T) {
 			// Should NOT reach here with limit=3
 			t.Error("should not fetch second page when limit already reached")
 			resp = map[string]interface{}{
-				"ok":       true,
-				"channels": []map[string]interface{}{{"id": "C4", "name": "ch4"}},
+				"ok":                true,
+				"channels":          []map[string]interface{}{{"id": "C4", "name": "ch4"}},
 				"response_metadata": map[string]string{"next_cursor": ""},
 			}
 		}
@@ -889,8 +889,8 @@ func TestClient_ListUsers_PaginationWithLimit(t *testing.T) {
 		} else {
 			t.Error("should not fetch second page when limit already reached")
 			resp = map[string]interface{}{
-				"ok":      true,
-				"members": []map[string]interface{}{{"id": "U3", "name": "user3"}},
+				"ok":                true,
+				"members":           []map[string]interface{}{{"id": "U3", "name": "user3"}},
 				"response_metadata": map[string]string{"next_cursor": ""},
 			}
 		}

--- a/internal/cmd/channels/channels_test.go
+++ b/internal/cmd/channels/channels_test.go
@@ -364,3 +364,21 @@ func TestRunArchive_InvalidChannelID(t *testing.T) {
 		})
 	}
 }
+
+func TestRunUnarchive_NotInChannel(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/conversations.unarchive", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":    false,
+			"error": "not_in_channel",
+		})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &unarchiveOptions{}
+
+	err := runUnarchive("C123", opts, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "not_in_channel")
+}

--- a/internal/cmd/channels/unarchive.go
+++ b/internal/cmd/channels/unarchive.go
@@ -1,6 +1,8 @@
 package channels
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/piekstra/slack-cli/internal/client"
@@ -32,6 +34,12 @@ func runUnarchive(channelID string, opts *unarchiveOptions, c *client.Client) er
 	}
 
 	if err := c.UnarchiveChannel(channelID); err != nil {
+		if strings.Contains(err.Error(), "not_in_channel") {
+			output.Println("Error: Cannot unarchive channel.")
+			output.Println("This is a Slack API limitation: bot tokens (xoxb-) cannot unarchive channels.")
+			output.Println("Workaround: Use a user token (xoxp-) or unarchive via the Slack UI.")
+			return err
+		}
 		return err
 	}
 


### PR DESCRIPTION
## Summary

- Add specific error handling that detects `not_in_channel` error on unarchive and displays a helpful message explaining the Slack API limitation
- Add Known Limitations section to README documenting this behavior
- Add unit test for the error handling

Fixes #26

## Background

Bot tokens (`xoxb-`) cannot unarchive channels due to a [documented Slack API limitation](https://api.slack.com/methods/conversations.unarchive). When a channel is archived, the bot is automatically removed. Bot tokens require membership to unarchive, creating a catch-22 situation.

## Changes

**`internal/cmd/channels/unarchive.go`**: Added detection of `not_in_channel` error with helpful messaging:
```
Error: Cannot unarchive channel.
This is a Slack API limitation: bot tokens (xoxb-) cannot unarchive channels.
Workaround: Use a user token (xoxp-) or unarchive via the Slack UI.
```

**`README.md`**: Added Known Limitations section documenting this behavior.

## Test plan

- [x] Unit tests pass (`make test`)
- [x] Integration test: Create channel, archive it, try to unarchive - helpful error message displayed
- [x] Build passes (`make build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)