### PR TITLE
docs: Add cleanup best practices to integration tests

### DIFF
--- a/integration-tests.md
+++ b/integration-tests.md
@@ -512,3 +512,34 @@ slack-cli search messages --help
 slack-cli config show
 slack-cli config test
 ```
+
+---
+
+## Cleanup Best Practices
+
+**Always clean up test artifacts.** Test messages left in shared channels create noise for other team members.
+
+### Guidelines
+
+1. **Track timestamps**: Save every TS value from message sends (TS₁, TS₂, TS₃, etc.)
+2. **Delete immediately after testing**: Don't batch cleanups - delete as you complete each test section
+3. **Verify deletion**: Check message history after cleanup to confirm removal
+4. **If interrupted**: Note any uncleaned timestamps and delete them before your next session
+
+### Quick Cleanup Commands
+
+```bash
+# Delete a single message
+slack-cli messages delete $TEST_CHANNEL_ID <timestamp> --force
+
+# Verify it's gone
+slack-cli messages history $TEST_CHANNEL_ID --limit 5
+```
+
+### What to Clean Up
+
+| Test Section | Artifacts | Cleanup Command |
+|--------------|-----------|-----------------|
+| Part 3 (Messaging) | Test messages TS₁, TS₂ | `messages delete` |
+| Part 3B (Search) | Search test message TS₃ | `messages delete` |
+| Part 5 (Destructive) | Test channels | `channels archive` |


### PR DESCRIPTION
## Summary

Adds a "Cleanup Best Practices" section to integration-tests.md emphasizing the importance of cleaning up test artifacts after testing.

## Changes

- Guidelines for tracking timestamps and deleting test messages
- Quick cleanup command reference
- Table of what to clean up for each test section

## Why

Test messages left in shared channels create noise for other team members. This documents the expectation that testers clean up after themselves.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)