### PR TITLE
feat: Rename project from slack-cli to slack-chat-api

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,27 +30,27 @@ jobs:
 
       - name: Build macOS ARM64
         run: |
-          GOOS=darwin GOARCH=arm64 go build -o slack-cli ./cmd/slack-cli
-          tar -czvf slack-cli_${{ env.TAG }}_darwin_arm64.tar.gz slack-cli
-          rm slack-cli
+          GOOS=darwin GOARCH=arm64 go build -o slack-chat-api ./cmd/slack-chat-api
+          tar -czvf slack-chat-api_${{ env.TAG }}_darwin_arm64.tar.gz slack-chat-api
+          rm slack-chat-api
 
       - name: Build macOS AMD64
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o slack-cli ./cmd/slack-cli
-          tar -czvf slack-cli_${{ env.TAG }}_darwin_amd64.tar.gz slack-cli
-          rm slack-cli
+          GOOS=darwin GOARCH=amd64 go build -o slack-chat-api ./cmd/slack-chat-api
+          tar -czvf slack-chat-api_${{ env.TAG }}_darwin_amd64.tar.gz slack-chat-api
+          rm slack-chat-api
 
       - name: Build Linux ARM64
         run: |
-          GOOS=linux GOARCH=arm64 go build -o slack-cli ./cmd/slack-cli
-          tar -czvf slack-cli_${{ env.TAG }}_linux_arm64.tar.gz slack-cli
-          rm slack-cli
+          GOOS=linux GOARCH=arm64 go build -o slack-chat-api ./cmd/slack-chat-api
+          tar -czvf slack-chat-api_${{ env.TAG }}_linux_arm64.tar.gz slack-chat-api
+          rm slack-chat-api
 
       - name: Build Linux AMD64
         run: |
-          GOOS=linux GOARCH=amd64 go build -o slack-cli ./cmd/slack-cli
-          tar -czvf slack-cli_${{ env.TAG }}_linux_amd64.tar.gz slack-cli
-          rm slack-cli
+          GOOS=linux GOARCH=amd64 go build -o slack-chat-api ./cmd/slack-chat-api
+          tar -czvf slack-chat-api_${{ env.TAG }}_linux_amd64.tar.gz slack-chat-api
+          rm slack-chat-api
 
       - name: Generate checksums
         run: |
@@ -72,72 +72,72 @@ jobs:
           VERSION="${{ env.TAG }}"
           VERSION_NUM="${VERSION#v}"
 
-          DARWIN_ARM64_SHA=$(shasum -a 256 slack-cli_${{ env.TAG }}_darwin_arm64.tar.gz | cut -d' ' -f1)
-          DARWIN_AMD64_SHA=$(shasum -a 256 slack-cli_${{ env.TAG }}_darwin_amd64.tar.gz | cut -d' ' -f1)
-          LINUX_ARM64_SHA=$(shasum -a 256 slack-cli_${{ env.TAG }}_linux_arm64.tar.gz | cut -d' ' -f1)
-          LINUX_AMD64_SHA=$(shasum -a 256 slack-cli_${{ env.TAG }}_linux_amd64.tar.gz | cut -d' ' -f1)
+          DARWIN_ARM64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_darwin_arm64.tar.gz | cut -d' ' -f1)
+          DARWIN_AMD64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_darwin_amd64.tar.gz | cut -d' ' -f1)
+          LINUX_ARM64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_linux_arm64.tar.gz | cut -d' ' -f1)
+          LINUX_AMD64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_linux_amd64.tar.gz | cut -d' ' -f1)
 
           git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/piekstra/homebrew-tap.git
           cd homebrew-tap
 
           mkdir -p Casks
 
-          cat > Casks/slack-cli.rb << 'CASKEOF'
-          cask "slack-cli" do
-            name "slack-cli"
+          cat > Casks/slack-chat-api.rb << 'CASKEOF'
+          cask "slack-chat-api" do
+            name "slack-chat-api"
             desc "Command-line interface for Slack"
-            homepage "https://github.com/piekstra/slack-cli"
+            homepage "https://github.com/piekstra/slack-chat-api"
             version "VERSION_PLACEHOLDER"
 
-            binary "slack-cli"
+            binary "slack-chat-api"
 
             on_macos do
               on_arm do
-                url "https://github.com/piekstra/slack-cli/releases/download/v#{version}/slack-cli_v#{version}_darwin_arm64.tar.gz"
+                url "https://github.com/piekstra/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_darwin_arm64.tar.gz"
                 sha256 "DARWIN_ARM64_PLACEHOLDER"
               end
               on_intel do
-                url "https://github.com/piekstra/slack-cli/releases/download/v#{version}/slack-cli_v#{version}_darwin_amd64.tar.gz"
+                url "https://github.com/piekstra/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_darwin_amd64.tar.gz"
                 sha256 "DARWIN_AMD64_PLACEHOLDER"
               end
             end
 
             on_linux do
               on_arm do
-                url "https://github.com/piekstra/slack-cli/releases/download/v#{version}/slack-cli_v#{version}_linux_arm64.tar.gz"
+                url "https://github.com/piekstra/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_linux_arm64.tar.gz"
                 sha256 "LINUX_ARM64_PLACEHOLDER"
               end
               on_intel do
-                url "https://github.com/piekstra/slack-cli/releases/download/v#{version}/slack-cli_v#{version}_linux_amd64.tar.gz"
+                url "https://github.com/piekstra/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_linux_amd64.tar.gz"
                 sha256 "LINUX_AMD64_PLACEHOLDER"
               end
             end
 
             postflight do
-              system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/slack-cli"]
+              system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/slack-chat-api"]
             end
 
             caveats <<~EOS
-              To configure slack-cli, run:
-                slack-cli config set-token
+              To configure slack-chat-api, run:
+                slack-chat-api config set-token
 
               On macOS, your token is stored securely in the system Keychain.
-              On Linux, your token is stored in ~/.config/slack-cli/credentials.
+              On Linux, your token is stored in ~/.config/slack-chat-api/credentials.
             EOS
           end
           CASKEOF
 
-          sed -i '' "s/VERSION_PLACEHOLDER/${VERSION_NUM}/g" Casks/slack-cli.rb
-          sed -i '' "s/DARWIN_ARM64_PLACEHOLDER/${DARWIN_ARM64_SHA}/g" Casks/slack-cli.rb
-          sed -i '' "s/DARWIN_AMD64_PLACEHOLDER/${DARWIN_AMD64_SHA}/g" Casks/slack-cli.rb
-          sed -i '' "s/LINUX_ARM64_PLACEHOLDER/${LINUX_ARM64_SHA}/g" Casks/slack-cli.rb
-          sed -i '' "s/LINUX_AMD64_PLACEHOLDER/${LINUX_AMD64_SHA}/g" Casks/slack-cli.rb
+          sed -i '' "s/VERSION_PLACEHOLDER/${VERSION_NUM}/g" Casks/slack-chat-api.rb
+          sed -i '' "s/DARWIN_ARM64_PLACEHOLDER/${DARWIN_ARM64_SHA}/g" Casks/slack-chat-api.rb
+          sed -i '' "s/DARWIN_AMD64_PLACEHOLDER/${DARWIN_AMD64_SHA}/g" Casks/slack-chat-api.rb
+          sed -i '' "s/LINUX_ARM64_PLACEHOLDER/${LINUX_ARM64_SHA}/g" Casks/slack-chat-api.rb
+          sed -i '' "s/LINUX_AMD64_PLACEHOLDER/${LINUX_AMD64_SHA}/g" Casks/slack-chat-api.rb
 
           # Remove old formula if it exists
-          rm -f Formula/slack-cli.rb
+          rm -f Formula/slack-chat-api.rb
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "Update slack-cli to ${VERSION_NUM}"
+          git commit -m "Update slack-chat-api to ${VERSION_NUM}"
           git push

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,6 +1,6 @@
 version: 2
 
-project_name: slack-cli
+project_name: slack-chat-api
 
 before:
   hooks:
@@ -8,7 +8,7 @@ before:
     - go test ./...
 
 builds:
-  - main: ./cmd/slack-cli
+  - main: ./cmd/slack-chat-api
     env:
       - CGO_ENABLED=0
     goos:
@@ -19,9 +19,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/piekstra/slack-cli/internal/version.Version={{.Version}}
-      - -X github.com/piekstra/slack-cli/internal/version.Commit={{.Commit}}
-      - -X github.com/piekstra/slack-cli/internal/version.Date={{.Date}}
+      - -X github.com/piekstra/slack-chat-api/internal/version.Version={{.Version}}
+      - -X github.com/piekstra/slack-chat-api/internal/version.Commit={{.Commit}}
+      - -X github.com/piekstra/slack-chat-api/internal/version.Date={{.Date}}
 
 archives:
   - format: tar.gz
@@ -55,20 +55,20 @@ changelog:
       order: 999
 
 brews:
-  - name: slack-cli
+  - name: slack-chat-api
     repository:
       owner: piekstra
       name: homebrew-tap
     directory: Formula
-    homepage: "https://github.com/piekstra/slack-cli"
+    homepage: "https://github.com/piekstra/slack-chat-api"
     description: "Command-line interface for Slack"
     license: "MIT"
     install: |
-      bin.install "slack-cli"
+      bin.install "slack-chat-api"
     caveats: |
-      To configure slack-cli, run:
-        slack-cli config set-token <your-slack-api-token>
+      To configure slack-chat-api, run:
+        slack-chat-api config set-token <your-slack-api-token>
 
       Or set the SLACK_API_TOKEN environment variable.
     test: |
-      assert_match "slack-cli", shell_output("#{bin}/slack-cli --help")
+      assert_match "slack-chat-api", shell_output("#{bin}/slack-chat-api --help")

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
-BINARY := slack-cli
+BINARY := slack-chat-api
 VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev")
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -ldflags "-s -w \
-	-X github.com/piekstra/slack-cli/internal/version.Version=$(VERSION) \
-	-X github.com/piekstra/slack-cli/internal/version.Commit=$(COMMIT) \
-	-X github.com/piekstra/slack-cli/internal/version.Date=$(DATE)"
+	-X github.com/piekstra/slack-chat-api/internal/version.Version=$(VERSION) \
+	-X github.com/piekstra/slack-chat-api/internal/version.Commit=$(COMMIT) \
+	-X github.com/piekstra/slack-chat-api/internal/version.Date=$(DATE)"
 
 DIST_DIR = dist
 
@@ -14,7 +14,7 @@ DIST_DIR = dist
 all: build
 
 build:
-	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/slack-cli
+	go build $(LDFLAGS) -o bin/$(BINARY) ./cmd/slack-chat-api
 
 test:
 	go test -v -race ./...
@@ -31,7 +31,7 @@ lint:
 
 fmt:
 	go fmt ./...
-	goimports -local github.com/piekstra/slack-cli -w .
+	goimports -local github.com/piekstra/slack-chat-api -w .
 
 deps:
 	go mod download
@@ -48,22 +48,22 @@ release: clean
 	mkdir -p $(DIST_DIR)
 
 	# macOS ARM64
-	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-cli
+	GOOS=darwin GOARCH=arm64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-chat-api
 	tar -czvf $(DIST_DIR)/$(BINARY)_$(VERSION)_darwin_arm64.tar.gz -C $(DIST_DIR) $(BINARY)
 	rm $(DIST_DIR)/$(BINARY)
 
 	# macOS AMD64
-	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-cli
+	GOOS=darwin GOARCH=amd64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-chat-api
 	tar -czvf $(DIST_DIR)/$(BINARY)_$(VERSION)_darwin_amd64.tar.gz -C $(DIST_DIR) $(BINARY)
 	rm $(DIST_DIR)/$(BINARY)
 
 	# Linux ARM64
-	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-cli
+	GOOS=linux GOARCH=arm64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-chat-api
 	tar -czvf $(DIST_DIR)/$(BINARY)_$(VERSION)_linux_arm64.tar.gz -C $(DIST_DIR) $(BINARY)
 	rm $(DIST_DIR)/$(BINARY)
 
 	# Linux AMD64
-	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-cli
+	GOOS=linux GOARCH=amd64 go build $(LDFLAGS) -o $(DIST_DIR)/$(BINARY) ./cmd/slack-chat-api
 	tar -czvf $(DIST_DIR)/$(BINARY)_$(VERSION)_linux_amd64.tar.gz -C $(DIST_DIR) $(BINARY)
 	rm $(DIST_DIR)/$(BINARY)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,26 @@
-# slack-cli
+# slack-chat-api
 
-A command-line interface for Slack.
+A lightweight command-line interface for interacting with the Slack Web API.
+
+## Not the Official Slack CLI
+
+This project is **not** affiliated with Slack or Salesforce. If you're looking to build Slack apps with workflows, triggers, and datastores, check out the [official Slack CLI](https://api.slack.com/automation/cli).
+
+**What's the difference?**
+
+| Feature | slack-chat-api (this project) | Official Slack CLI |
+|---------|-------------------------------|-------------------|
+| **Purpose** | Direct API access for automation & scripting | Build and deploy Slack apps |
+| **Use cases** | Send messages, manage channels, search, CI/CD integration | Workflows, triggers, datastores, app development |
+| **Authentication** | Bot/User OAuth tokens | Slack app credentials |
+| **Complexity** | Simple, single binary | Full development framework |
+
+**When to use slack-chat-api:**
+- Sending notifications from CI/CD pipelines
+- Automating channel management
+- Scripting message operations
+- Quick API interactions from the terminal
+- Integrating Slack into shell scripts or automation tools
 
 ## Installation
 
@@ -8,20 +28,20 @@ A command-line interface for Slack.
 
 ```bash
 brew tap piekstra/tap
-brew install --cask slack-cli
+brew install --cask piekstra/tap/slack-chat-api
 ```
 
 ### From Source
 
 ```bash
-go install github.com/piekstra/slack-cli@latest
+go install github.com/piekstra/slack-chat-api@latest
 ```
 
 ### Manual Build
 
 ```bash
-git clone https://github.com/piekstra/slack-cli.git
-cd slack-cli
+git clone https://github.com/piekstra/slack-chat-api.git
+cd slack-chat-api
 make build
 ```
 
@@ -30,7 +50,7 @@ make build
 | Platform | Credential Storage |
 |----------|-------------------|
 | macOS | Secure (Keychain) |
-| Linux | Config file (`~/.config/slack-cli/credentials`) |
+| Linux | Config file (`~/.config/slack-chat-api/credentials`) |
 
 **Note:** On Linux, credentials are stored in a file with restricted permissions (0600). While not as secure as macOS Keychain, this is standard practice for CLI tools on Linux.
 
@@ -43,7 +63,7 @@ make build
 3. Paste this manifest (YAML tab):
    ```yaml
    display_information:
-     name: Slack CLI
+     name: Slack Chat API
    oauth_config:
      scopes:
        bot:
@@ -66,7 +86,7 @@ make build
 5. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
 6. Run:
    ```bash
-   slack-cli config set-token
+   slack-chat-api config set-token
    # Paste your token when prompted
    ```
 
@@ -84,21 +104,21 @@ Use a shell function to lazy-load your token from 1Password on first use:
 
 ```bash
 # Add to ~/.zshrc or ~/.bashrc
-slack() {
+slack-chat() {
   if [[ -z "$SLACK_API_TOKEN" ]]; then
-    export SLACK_API_TOKEN="$(op read 'op://Personal/slack-cli/api_token')"
+    export SLACK_API_TOKEN="$(op read 'op://Personal/slack-chat-api/api_token')"
   fi
-  command slack-cli "$@"
+  command slack-chat-api "$@"
 }
 ```
 
 Or create an alias that always fetches fresh:
 
 ```bash
-alias slack='SLACK_API_TOKEN="$(op read '\''op://Personal/slack-cli/api_token'\'')" slack-cli'
+alias slack-chat='SLACK_API_TOKEN="$(op read '\''op://Personal/slack-chat-api/api_token'\'')" slack-chat-api'
 ```
 
-Replace `op://Personal/slack-cli/api_token` with your 1Password secret reference.
+Replace `op://Personal/slack-chat-api/api_token` with your 1Password secret reference.
 
 ### Required Scopes
 
@@ -132,10 +152,10 @@ Most commands use the **bot token**. Search commands require a **user token**.
 
 ```bash
 # Set bot token (for channels, users, messages, workspace)
-slack-cli config set-token xoxb-your-bot-token
+slack-chat-api config set-token xoxb-your-bot-token
 
 # Set user token (for search)
-slack-cli config set-token xoxp-your-user-token
+slack-chat-api config set-token xoxp-your-user-token
 ```
 
 The `set-token` command automatically detects the token type and stores it appropriately.
@@ -171,30 +191,30 @@ These flags are available on all commands:
 
 ```bash
 # List all channels
-slack-cli channels list
+slack-chat-api channels list
 
 # List with options
-slack-cli channels list --types public_channel,private_channel  # Include private channels
-slack-cli channels list --limit 50                              # Limit results
-slack-cli channels list --exclude-archived=false                # Include archived channels
+slack-chat-api channels list --types public_channel,private_channel  # Include private channels
+slack-chat-api channels list --limit 50                              # Limit results
+slack-chat-api channels list --exclude-archived=false                # Include archived channels
 
 # Get channel info
-slack-cli channels get C1234567890
+slack-chat-api channels get C1234567890
 
 # Create a channel
-slack-cli channels create my-new-channel
-slack-cli channels create private-channel --private
+slack-chat-api channels create my-new-channel
+slack-chat-api channels create private-channel --private
 
 # Archive/unarchive
-slack-cli channels archive C1234567890
-slack-cli channels unarchive C1234567890
+slack-chat-api channels archive C1234567890
+slack-chat-api channels unarchive C1234567890
 
 # Set topic/purpose
-slack-cli channels set-topic C1234567890 "New topic"
-slack-cli channels set-purpose C1234567890 "Channel purpose"
+slack-chat-api channels set-topic C1234567890 "New topic"
+slack-chat-api channels set-purpose C1234567890 "Channel purpose"
 
 # Invite users
-slack-cli channels invite C1234567890 U1111111111 U2222222222
+slack-chat-api channels invite C1234567890 U1111111111 U2222222222
 ```
 
 #### Channels Command Reference
@@ -214,11 +234,11 @@ slack-cli channels invite C1234567890 U1111111111 U2222222222
 
 ```bash
 # List all users
-slack-cli users list
-slack-cli users list --limit 50
+slack-chat-api users list
+slack-chat-api users list --limit 50
 
 # Get user info
-slack-cli users get U1234567890
+slack-chat-api users get U1234567890
 ```
 
 #### Users Command Reference
@@ -232,41 +252,41 @@ slack-cli users get U1234567890
 
 ```bash
 # Send a message (uses Block Kit formatting by default)
-slack-cli messages send C1234567890 "Hello, *world*!"
+slack-chat-api messages send C1234567890 "Hello, *world*!"
 
 # Send from stdin (use "-" as text argument)
-echo "Hello from stdin" | slack-cli messages send C1234567890 -
-cat message.txt | slack-cli messages send C1234567890 -
+echo "Hello from stdin" | slack-chat-api messages send C1234567890 -
+cat message.txt | slack-chat-api messages send C1234567890 -
 
 # Send plain text (no formatting)
-slack-cli messages send C1234567890 "Plain text" --simple
+slack-chat-api messages send C1234567890 "Plain text" --simple
 
 # Send with custom Block Kit blocks
-slack-cli messages send C1234567890 "Fallback" --blocks '[{"type":"section","text":{"type":"mrkdwn","text":"*Bold*"}}]'
+slack-chat-api messages send C1234567890 "Fallback" --blocks '[{"type":"section","text":{"type":"mrkdwn","text":"*Bold*"}}]'
 
 # Reply in a thread
-slack-cli messages send C1234567890 "Thread reply" --thread 1234567890.123456
+slack-chat-api messages send C1234567890 "Thread reply" --thread 1234567890.123456
 
 # Update a message
-slack-cli messages update C1234567890 1234567890.123456 "Updated text"
-slack-cli messages update C1234567890 1234567890.123456 "Plain update" --simple
+slack-chat-api messages update C1234567890 1234567890.123456 "Updated text"
+slack-chat-api messages update C1234567890 1234567890.123456 "Plain update" --simple
 
 # Delete a message
-slack-cli messages delete C1234567890 1234567890.123456
+slack-chat-api messages delete C1234567890 1234567890.123456
 
 # Get channel history
-slack-cli messages history C1234567890
-slack-cli messages history C1234567890 --limit 50
-slack-cli messages history C1234567890 --oldest 1234567890.000000  # After this time
-slack-cli messages history C1234567890 --latest 1234567890.000000  # Before this time
+slack-chat-api messages history C1234567890
+slack-chat-api messages history C1234567890 --limit 50
+slack-chat-api messages history C1234567890 --oldest 1234567890.000000  # After this time
+slack-chat-api messages history C1234567890 --latest 1234567890.000000  # Before this time
 
 # Get thread replies
-slack-cli messages thread C1234567890 1234567890.123456
-slack-cli messages thread C1234567890 1234567890.123456 --limit 50
+slack-chat-api messages thread C1234567890 1234567890.123456
+slack-chat-api messages thread C1234567890 1234567890.123456 --limit 50
 
 # Add/remove reactions
-slack-cli messages react C1234567890 1234567890.123456 thumbsup
-slack-cli messages unreact C1234567890 1234567890.123456 thumbsup
+slack-chat-api messages react C1234567890 1234567890.123456 thumbsup
+slack-chat-api messages unreact C1234567890 1234567890.123456 thumbsup
 ```
 
 #### Messages Command Reference
@@ -287,20 +307,20 @@ slack-cli messages unreact C1234567890 1234567890.123456 thumbsup
 
 ```bash
 # Search messages
-slack-cli search messages "quarterly report"
-slack-cli search messages "in:#general bug fix"
-slack-cli search messages "from:@alice project update"
+slack-chat-api search messages "quarterly report"
+slack-chat-api search messages "in:#general bug fix"
+slack-chat-api search messages "from:@alice project update"
 
 # Search files
-slack-cli search files "budget spreadsheet"
-slack-cli search files "type:pdf report"
+slack-chat-api search files "budget spreadsheet"
+slack-chat-api search files "type:pdf report"
 
 # Search all (messages + files)
-slack-cli search all "project proposal"
-slack-cli search all "quarterly" --sort timestamp
+slack-chat-api search all "project proposal"
+slack-chat-api search all "quarterly" --sort timestamp
 
 # With pagination
-slack-cli search messages "error" --count 50 --page 2
+slack-chat-api search messages "error" --count 50 --page 2
 ```
 
 #### Search Modifiers
@@ -337,23 +357,23 @@ slack-cli search messages "error" --count 50 --page 2
 
 ```bash
 # Get workspace info
-slack-cli workspace info
+slack-chat-api workspace info
 ```
 
 ### Config
 
 ```bash
 # Set API token (interactive prompt)
-slack-cli config set-token
+slack-chat-api config set-token
 
 # Set API token directly
-slack-cli config set-token xoxb-your-token-here
+slack-chat-api config set-token xoxb-your-token-here
 
 # Show current config status
-slack-cli config show
+slack-chat-api config show
 
 # Delete stored token
-slack-cli config delete-token
+slack-chat-api config delete-token
 ```
 
 #### Config Command Reference
@@ -376,30 +396,30 @@ All commands support multiple output formats via the `--output` (or `-o`) flag:
 
 ```bash
 # Default text output
-slack-cli channels list
+slack-chat-api channels list
 
 # JSON output (for scripting)
-slack-cli channels list --output json
-slack-cli users get U1234567890 -o json
+slack-chat-api channels list --output json
+slack-chat-api users get U1234567890 -o json
 
 # Table output (aligned columns)
-slack-cli channels list --output table
+slack-chat-api channels list --output table
 ```
 
 ### Shell Completion
 
 ```bash
 # Bash
-slack-cli completion bash > /etc/bash_completion.d/slack-cli
+slack-chat-api completion bash > /etc/bash_completion.d/slack-chat-api
 
 # Zsh
-slack-cli completion zsh > "${fpath[1]}/_slack-cli"
+slack-chat-api completion zsh > "${fpath[1]}/_slack-chat-api"
 
 # Fish
-slack-cli completion fish > ~/.config/fish/completions/slack-cli.fish
+slack-chat-api completion fish > ~/.config/fish/completions/slack-chat-api.fish
 
 # PowerShell
-slack-cli completion powershell > slack-cli.ps1
+slack-chat-api completion powershell > slack-chat-api.ps1
 ```
 
 ## Aliases

--- a/cmd/slack-chat-api/main.go
+++ b/cmd/slack-chat-api/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/piekstra/slack-cli/internal/cmd/root"
+	"github.com/piekstra/slack-chat-api/internal/cmd/root"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/piekstra/slack-cli
+module github.com/piekstra/slack-chat-api
 
 go 1.21
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/piekstra/slack-cli/internal/keychain"
+	"github.com/piekstra/slack-chat-api/internal/keychain"
 )
 
 const defaultBaseURL = "https://slack.com/api"

--- a/internal/client/errors.go
+++ b/internal/client/errors.go
@@ -7,12 +7,12 @@ import (
 
 // errorHints maps Slack API error codes to helpful hints.
 var errorHints = map[string]string{
-	"channel_not_found":    "Verify the channel ID is correct. Use 'slack-cli channels list' to find channel IDs.",
+	"channel_not_found":    "Verify the channel ID is correct. Use 'slack-chat-api channels list' to find channel IDs.",
 	"not_in_channel":       "The bot must be invited to the channel. Use /invite @yourbot in Slack.",
-	"invalid_auth":         "Token is invalid or expired. Run 'slack-cli config set-token' to set a new token.",
-	"token_revoked":        "Token has been revoked. Run 'slack-cli config set-token' to set a new token.",
+	"invalid_auth":         "Token is invalid or expired. Run 'slack-chat-api config set-token' to set a new token.",
+	"token_revoked":        "Token has been revoked. Run 'slack-chat-api config set-token' to set a new token.",
 	"ratelimited":          "Rate limit exceeded. Wait a moment and try again.",
-	"user_not_found":       "Verify the user ID is correct. Use 'slack-cli users list' to find user IDs.",
+	"user_not_found":       "Verify the user ID is correct. Use 'slack-chat-api users list' to find user IDs.",
 	"message_not_found":    "Message not found. Verify the channel ID and timestamp are correct.",
 	"cant_delete_message":  "Cannot delete this message. You can only delete messages sent by the bot.",
 	"cant_update_message":  "Cannot update this message. You can only update messages sent by the bot.",

--- a/internal/client/errors_test.go
+++ b/internal/client/errors_test.go
@@ -56,7 +56,7 @@ func TestWrapError(t *testing.T) {
 			name:       "user_not_found includes list hint",
 			operation:  "get user",
 			inputErr:   fmt.Errorf("user_not_found"),
-			wantHint:   "slack-cli users list",
+			wantHint:   "slack-chat-api users list",
 			shouldHint: true,
 		},
 		{

--- a/internal/cmd/channels/archive.go
+++ b/internal/cmd/channels/archive.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
-	"github.com/piekstra/slack-cli/internal/validate"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/validate"
 )
 
 type archiveOptions struct {

--- a/internal/cmd/channels/channels_test.go
+++ b/internal/cmd/channels/channels_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-cli/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/client"
 )
 
 func TestRunList_Success(t *testing.T) {

--- a/internal/cmd/channels/create.go
+++ b/internal/cmd/channels/create.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type createOptions struct {

--- a/internal/cmd/channels/get.go
+++ b/internal/cmd/channels/get.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type getOptions struct{}

--- a/internal/cmd/channels/invite.go
+++ b/internal/cmd/channels/invite.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type inviteOptions struct{}

--- a/internal/cmd/channels/list.go
+++ b/internal/cmd/channels/list.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type listOptions struct {

--- a/internal/cmd/channels/set_purpose.go
+++ b/internal/cmd/channels/set_purpose.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type setPurposeOptions struct{}

--- a/internal/cmd/channels/set_topic.go
+++ b/internal/cmd/channels/set_topic.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type setTopicOptions struct{}

--- a/internal/cmd/channels/unarchive.go
+++ b/internal/cmd/channels/unarchive.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type unarchiveOptions struct{}

--- a/internal/cmd/config/config.go
+++ b/internal/cmd/config/config.go
@@ -8,7 +8,7 @@ import (
 func NewCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "config",
-		Short: "Configure slack-cli",
+		Short: "Configure slack-chat-api",
 	}
 
 	cmd.AddCommand(newSetTokenCmd())

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-cli/internal/keychain"
+	"github.com/piekstra/slack-chat-api/internal/keychain"
 )
 
 func TestRunSetToken_Success(t *testing.T) {

--- a/internal/cmd/config/delete_token.go
+++ b/internal/cmd/config/delete_token.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/keychain"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/keychain"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type deleteTokenOptions struct {

--- a/internal/cmd/config/set_token.go
+++ b/internal/cmd/config/set_token.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/keychain"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/keychain"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type setTokenOptions struct{}
@@ -27,7 +27,7 @@ Token types are detected automatically:
   - User tokens (xoxp-*): Used for search commands
 
 On macOS: Tokens are stored securely in the system Keychain.
-On Linux: Tokens are stored in ~/.config/slack-cli/credentials (file permissions 0600).
+On Linux: Tokens are stored in ~/.config/slack-chat-api/credentials (file permissions 0600).
 
 If no token is provided as an argument, you will be prompted to enter it.`,
 		Args: cobra.MaximumNArgs(1),
@@ -45,7 +45,7 @@ func runSetToken(token string, opts *setTokenOptions) error {
 	// Warn Linux users about file-based storage
 	if !keychain.IsSecureStorage() {
 		output.Println("Warning: On Linux, your token will be stored in a config file")
-		output.Println("         (~/.config/slack-cli/credentials) with restricted permissions (0600).")
+		output.Println("         (~/.config/slack-chat-api/credentials) with restricted permissions (0600).")
 		output.Println("         This is less secure than macOS Keychain storage.")
 		output.Println()
 	}
@@ -75,7 +75,7 @@ func runSetToken(token string, opts *setTokenOptions) error {
 		if keychain.IsSecureStorage() {
 			output.Println("Bot token stored securely in Keychain")
 		} else {
-			output.Println("Bot token stored in ~/.config/slack-cli/credentials")
+			output.Println("Bot token stored in ~/.config/slack-chat-api/credentials")
 		}
 	case "user":
 		if err := keychain.SetUserToken(token); err != nil {
@@ -84,7 +84,7 @@ func runSetToken(token string, opts *setTokenOptions) error {
 		if keychain.IsSecureStorage() {
 			output.Println("User token stored securely in Keychain")
 		} else {
-			output.Println("User token stored in ~/.config/slack-cli/credentials")
+			output.Println("User token stored in ~/.config/slack-chat-api/credentials")
 		}
 		output.Println("Note: This token will be used for search commands.")
 	default:

--- a/internal/cmd/config/show.go
+++ b/internal/cmd/config/show.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/keychain"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/keychain"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type showOptions struct{}
@@ -54,7 +54,7 @@ func runShow(opts *showOptions) error {
 	}
 
 	if !hasAnyToken {
-		output.Println("\nRun 'slack-cli config set-token' to configure")
+		output.Println("\nRun 'slack-chat-api config set-token' to configure")
 	}
 
 	return nil

--- a/internal/cmd/config/test.go
+++ b/internal/cmd/config/test.go
@@ -3,8 +3,8 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type testOptions struct{}
@@ -79,7 +79,7 @@ func runTest(opts *testOptions, botClient *client.Client, userClient *client.Cli
 
 	if !anySuccess {
 		output.Println()
-		output.Println("No valid tokens configured. Run 'slack-cli config set-token' to configure.")
+		output.Println("No valid tokens configured. Run 'slack-chat-api config set-token' to configure.")
 	}
 
 	return nil

--- a/internal/cmd/config/test_test.go
+++ b/internal/cmd/config/test_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/keychain"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/keychain"
 )
 
 func TestRunTest_Success(t *testing.T) {

--- a/internal/cmd/messages/delete.go
+++ b/internal/cmd/messages/delete.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
-	"github.com/piekstra/slack-cli/internal/validate"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/validate"
 )
 
 type deleteOptions struct {

--- a/internal/cmd/messages/history.go
+++ b/internal/cmd/messages/history.go
@@ -3,8 +3,8 @@ package messages
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type historyOptions struct {

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-cli/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/client"
 )
 
 func TestFormatTimestamp(t *testing.T) {

--- a/internal/cmd/messages/react.go
+++ b/internal/cmd/messages/react.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
-	"github.com/piekstra/slack-cli/internal/validate"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/validate"
 )
 
 type reactOptions struct{}

--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
-	"github.com/piekstra/slack-cli/internal/validate"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/validate"
 )
 
 type sendOptions struct {
@@ -33,8 +33,8 @@ By default, messages are sent using Slack Block Kit formatting for a more
 refined appearance. Use --simple to send plain text messages instead.
 
 Use "-" as the text argument to read from stdin:
-  echo "Hello" | slack-cli messages send C1234567890 -
-  cat message.txt | slack-cli messages send C1234567890 -`,
+  echo "Hello" | slack-chat-api messages send C1234567890 -
+  cat message.txt | slack-chat-api messages send C1234567890 -`,
 		Args: cobra.ExactArgs(2),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSend(args[0], args[1], opts, nil)

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -3,8 +3,8 @@ package messages
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type threadOptions struct {

--- a/internal/cmd/messages/unreact.go
+++ b/internal/cmd/messages/unreact.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
-	"github.com/piekstra/slack-cli/internal/validate"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/validate"
 )
 
 type unreactOptions struct{}

--- a/internal/cmd/messages/update.go
+++ b/internal/cmd/messages/update.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type updateOptions struct {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -6,28 +6,28 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/cmd/channels"
-	"github.com/piekstra/slack-cli/internal/cmd/config"
-	"github.com/piekstra/slack-cli/internal/cmd/messages"
-	"github.com/piekstra/slack-cli/internal/cmd/search"
-	"github.com/piekstra/slack-cli/internal/cmd/users"
-	"github.com/piekstra/slack-cli/internal/cmd/workspace"
-	"github.com/piekstra/slack-cli/internal/output"
-	"github.com/piekstra/slack-cli/internal/version"
+	"github.com/piekstra/slack-chat-api/internal/cmd/channels"
+	"github.com/piekstra/slack-chat-api/internal/cmd/config"
+	"github.com/piekstra/slack-chat-api/internal/cmd/messages"
+	"github.com/piekstra/slack-chat-api/internal/cmd/search"
+	"github.com/piekstra/slack-chat-api/internal/cmd/users"
+	"github.com/piekstra/slack-chat-api/internal/cmd/workspace"
+	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/version"
 )
 
 var outputFormat string
 
 var rootCmd = &cobra.Command{
-	Use:   "slack-cli",
+	Use:   "slack-chat-api",
 	Short: "A CLI tool for interacting with Slack",
-	Long: `slack-cli is a command-line interface for Slack.
+	Long: `slack-chat-api is a command-line interface for Slack.
 
 It provides commands for managing channels, users, messages,
 and other Slack workspace operations.
 
 Configure your API token with:
-  slack-cli config set-token <your-token>
+  slack-chat-api config set-token <your-token>
 
 Or set the SLACK_API_TOKEN environment variable.`,
 	Version: version.Version,
@@ -55,7 +55,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&output.NoColor, "no-color", false, "Disable colored output")
 
 	// Set custom version template to include commit and build date
-	rootCmd.SetVersionTemplate("slack-cli " + version.Info() + "\n")
+	rootCmd.SetVersionTemplate("slack-chat-api " + version.Info() + "\n")
 
 	// Add subcommands
 	rootCmd.AddCommand(channels.NewCmd())

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -3,8 +3,8 @@ package search
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type allOptions struct {
@@ -34,9 +34,9 @@ Search modifiers:
   after:date     Content after date (YYYY-MM-DD)
 
 Examples:
-  slack-cli search all "project proposal"
-  slack-cli search all "quarterly report" --sort timestamp
-  slack-cli search all "from:@alice important"`,
+  slack-chat-api search all "project proposal"
+  slack-chat-api search all "quarterly report" --sort timestamp
+  slack-chat-api search all "from:@alice important"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearchAll(args[0], opts, nil)

--- a/internal/cmd/search/files.go
+++ b/internal/cmd/search/files.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type filesOptions struct {
@@ -35,10 +35,10 @@ Search modifiers:
   after:date     Files after date (YYYY-MM-DD)
 
 Examples:
-  slack-cli search files "budget spreadsheet"
-  slack-cli search files "in:#finance quarterly report"
-  slack-cli search files "from:@alice type:pdf"
-  slack-cli search files "type:image logo"`,
+  slack-chat-api search files "budget spreadsheet"
+  slack-chat-api search files "in:#finance quarterly report"
+  slack-chat-api search files "from:@alice type:pdf"
+  slack-chat-api search files "type:image logo"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearchFiles(args[0], opts, nil)

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type messagesOptions struct {
@@ -40,10 +40,10 @@ Search modifiers:
   has:reaction   Messages with reactions
 
 Examples:
-  slack-cli search messages "quarterly report"
-  slack-cli search messages "in:#engineering bug fix"
-  slack-cli search messages "from:@alice project update"
-  slack-cli search messages "after:2025-01-01 deployment"`,
+  slack-chat-api search messages "quarterly report"
+  slack-chat-api search messages "in:#engineering bug fix"
+  slack-chat-api search messages "from:@alice project update"
+  slack-chat-api search messages "after:2025-01-01 deployment"`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearchMessages(args[0], opts, nil)

--- a/internal/cmd/search/search.go
+++ b/internal/cmd/search/search.go
@@ -18,7 +18,7 @@ To set up a user token:
   2. Add 'search:read' to User Token Scopes
   3. Reinstall the app to your workspace
   4. Copy the User OAuth Token (starts with xoxp-)
-  5. Run: slack-cli config set-token <your-xoxp-token>`,
+  5. Run: slack-chat-api config set-token <your-xoxp-token>`,
 	}
 
 	cmd.AddCommand(newMessagesCmd())

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/piekstra/slack-cli/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/client"
 )
 
 // Helper to create a test client with a mock server

--- a/internal/cmd/users/get.go
+++ b/internal/cmd/users/get.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type getOptions struct{}

--- a/internal/cmd/users/list.go
+++ b/internal/cmd/users/list.go
@@ -3,8 +3,8 @@ package users
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type listOptions struct {

--- a/internal/cmd/users/users_test.go
+++ b/internal/cmd/users/users_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-cli/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/client"
 )
 
 func TestRunList_Success(t *testing.T) {

--- a/internal/cmd/workspace/info.go
+++ b/internal/cmd/workspace/info.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-cli/internal/client"
-	"github.com/piekstra/slack-cli/internal/output"
+	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/output"
 )
 
 type infoOptions struct{}

--- a/internal/cmd/workspace/workspace_test.go
+++ b/internal/cmd/workspace/workspace_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-cli/internal/client"
+	"github.com/piekstra/slack-chat-api/internal/client"
 )
 
 func TestRunInfo_Success(t *testing.T) {

--- a/internal/keychain/keychain.go
+++ b/internal/keychain/keychain.go
@@ -10,7 +10,7 @@ import (
 )
 
 const (
-	serviceName  = "slack-cli"
+	serviceName  = "slack-chat-api"
 	apiTokenKey  = "api_token"
 	userTokenKey = "user_token"
 )
@@ -29,7 +29,7 @@ func GetAPIToken() (string, error) {
 		return token, nil
 	}
 
-	return "", fmt.Errorf("no API token found - run 'slack-cli config set-token' or set SLACK_API_TOKEN")
+	return "", fmt.Errorf("no API token found - run 'slack-chat-api config set-token' or set SLACK_API_TOKEN")
 }
 
 // SetAPIToken stores the Slack API token
@@ -82,7 +82,7 @@ func GetUserToken() (string, error) {
 		return token, nil
 	}
 
-	return "", fmt.Errorf("no user token found - run 'slack-cli config set-token <xoxp-token>' or set SLACK_USER_TOKEN")
+	return "", fmt.Errorf("no user token found - run 'slack-chat-api config set-token <xoxp-token>' or set SLACK_USER_TOKEN")
 }
 
 // SetUserToken stores a user token
@@ -190,10 +190,10 @@ func deleteFromKeychain(account string) error {
 
 func getConfigDir() string {
 	if xdgConfig := os.Getenv("XDG_CONFIG_HOME"); xdgConfig != "" {
-		return filepath.Join(xdgConfig, "slack-cli")
+		return filepath.Join(xdgConfig, "slack-chat-api")
 	}
 	home, _ := os.UserHomeDir()
-	return filepath.Join(home, ".config", "slack-cli")
+	return filepath.Join(home, ".config", "slack-chat-api")
 }
 
 func getConfigFilePath() string {

--- a/internal/keychain/keychain_test.go
+++ b/internal/keychain/keychain_test.go
@@ -83,7 +83,7 @@ func TestGetConfigDir_Default(t *testing.T) {
 	_ = os.Unsetenv("XDG_CONFIG_HOME")
 
 	home, _ := os.UserHomeDir()
-	expected := filepath.Join(home, ".config", "slack-cli")
+	expected := filepath.Join(home, ".config", "slack-chat-api")
 	actual := getConfigDir()
 
 	if actual != expected {
@@ -95,7 +95,7 @@ func TestGetConfigDir_XDGConfigHome(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("XDG_CONFIG_HOME", tmpDir)
 
-	expected := filepath.Join(tmpDir, "slack-cli")
+	expected := filepath.Join(tmpDir, "slack-chat-api")
 	actual := getConfigDir()
 
 	if actual != expected {
@@ -117,7 +117,7 @@ func TestConfigFile_SetAndGet(t *testing.T) {
 	}
 
 	// Verify config directory was created
-	configDir := filepath.Join(tmpDir, "slack-cli")
+	configDir := filepath.Join(tmpDir, "slack-chat-api")
 	info, err := os.Stat(configDir)
 	if err != nil {
 		t.Fatalf("config directory not created: %v", err)
@@ -266,7 +266,7 @@ func TestConfigFile_Permissions(t *testing.T) {
 	}
 
 	// Check file permissions (should be 0600)
-	configPath := filepath.Join(tmpDir, "slack-cli", "credentials")
+	configPath := filepath.Join(tmpDir, "slack-chat-api", "credentials")
 	info, err := os.Stat(configPath)
 	if err != nil {
 		t.Fatalf("stat failed: %v", err)
@@ -278,7 +278,7 @@ func TestConfigFile_Permissions(t *testing.T) {
 	}
 
 	// Check directory permissions (should be 0700)
-	dirInfo, err := os.Stat(filepath.Join(tmpDir, "slack-cli"))
+	dirInfo, err := os.Stat(filepath.Join(tmpDir, "slack-chat-api"))
 	if err != nil {
 		t.Fatalf("stat dir failed: %v", err)
 	}

--- a/slack-app-manifest.yaml
+++ b/slack-app-manifest.yaml
@@ -1,6 +1,6 @@
 display_information:
-  name: Slack CLI
-  description: Command-line interface for Slack
+  name: Slack Chat API
+  description: Command-line interface for Slack Chat API
   background_color: "#4A154B"
 
 oauth_config:


### PR DESCRIPTION
## Summary

Renames the project from `slack-cli` to `slack-chat-api` to avoid confusion with the [official Slack CLI](https://api.slack.com/automation/cli).

**Changes:**
- Rename binary from `slack-cli` to `slack-chat-api`
- Update Go module path to `github.com/piekstra/slack-chat-api`
- Rename `cmd/slack-cli` to `cmd/slack-chat-api`
- Update all import paths and internal references
- Update README with clear distinction from official Slack CLI
- Update release workflow, goreleaser, and Makefile
- Update credential storage paths and keychain service names

## Test Plan

- [x] Build compiles successfully
- [x] All tests pass
- [ ] Manually test `slack-chat-api --version`
- [ ] After merge, trigger release workflow to publish v3.0.0
- [ ] Update homebrew-tap with new cask name