### PR TITLE
fix: Add ldflags to release builds and auto-merge release PRs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,6 +14,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: googleapis/release-please-action@v4
+        id: release
         with:
           release-type: go
           token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-merge release PR
+        if: steps.release.outputs.pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr merge ${{ steps.release.outputs.pr }} --repo ${{ github.repository }} --auto --squash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,27 +28,50 @@ jobs:
         with:
           go-version: "1.21"
 
+      - name: Set build variables
+        id: vars
+        run: |
+          echo "VERSION=${{ env.TAG }}" >> $GITHUB_OUTPUT
+          echo "COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
+          echo "DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+
       - name: Build macOS ARM64
         run: |
-          GOOS=darwin GOARCH=arm64 go build -o slack-chat-api ./cmd/slack-chat-api
+          GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w \
+            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
+            -o slack-chat-api ./cmd/slack-chat-api
           tar -czvf slack-chat-api_${{ env.TAG }}_darwin_arm64.tar.gz slack-chat-api
           rm slack-chat-api
 
       - name: Build macOS AMD64
         run: |
-          GOOS=darwin GOARCH=amd64 go build -o slack-chat-api ./cmd/slack-chat-api
+          GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w \
+            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
+            -o slack-chat-api ./cmd/slack-chat-api
           tar -czvf slack-chat-api_${{ env.TAG }}_darwin_amd64.tar.gz slack-chat-api
           rm slack-chat-api
 
       - name: Build Linux ARM64
         run: |
-          GOOS=linux GOARCH=arm64 go build -o slack-chat-api ./cmd/slack-chat-api
+          GOOS=linux GOARCH=arm64 go build -ldflags "-s -w \
+            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
+            -o slack-chat-api ./cmd/slack-chat-api
           tar -czvf slack-chat-api_${{ env.TAG }}_linux_arm64.tar.gz slack-chat-api
           rm slack-chat-api
 
       - name: Build Linux AMD64
         run: |
-          GOOS=linux GOARCH=amd64 go build -o slack-chat-api ./cmd/slack-chat-api
+          GOOS=linux GOARCH=amd64 go build -ldflags "-s -w \
+            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
+            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
+            -o slack-chat-api ./cmd/slack-chat-api
           tar -czvf slack-chat-api_${{ env.TAG }}_linux_amd64.tar.gz slack-chat-api
           rm slack-chat-api
 


### PR DESCRIPTION
## Summary

Two fixes for the release process:

1. **Add ldflags to release builds** - Binaries now include proper version info instead of showing "dev"
2. **Auto-merge release-please PRs** - Releases are now fully automatic, no manual approval needed

## Changes

**release.yml:**
- Added build variables step to capture version, commit, and date
- Added `-ldflags` to all build commands with version info

**release-please.yml:**
- Added auto-merge step that runs after release-please creates a PR
- Uses `gh pr merge --auto --squash` to enable auto-merge

## Test Plan

- [ ] Merge this PR
- [ ] Make a small change and push to main
- [ ] Verify release-please PR is created and auto-merged
- [ ] Verify release binaries have correct version info