### PR TITLE
fix: Use PAT for release-please to trigger release workflow

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,16 +13,18 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      # Use PAT instead of GITHUB_TOKEN so release events trigger the release workflow
+      # (GITHUB_TOKEN doesn't trigger workflows to prevent infinite loops)
       - uses: googleapis/release-please-action@v4
         id: release
         with:
           release-type: go
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TAP_GITHUB_TOKEN }}
 
       - name: Auto-merge release PR
         if: steps.release.outputs.prs_created == 'true'
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
           PR_NUMBER: ${{ fromJSON(steps.release.outputs.pr).number }}
         run: |
           gh pr merge "$PR_NUMBER" --repo ${{ github.repository }} --auto --squash


### PR DESCRIPTION
## Summary

Uses `TAP_GITHUB_TOKEN` (PAT) instead of `GITHUB_TOKEN` for release-please.

**Why:** When `GITHUB_TOKEN` creates a release, GitHub doesn't trigger other workflows (security feature to prevent infinite loops). Using a PAT allows the release event to properly trigger the release workflow.

## Test Plan

- [ ] Merge this PR
- [ ] Make a change that triggers a release (e.g., `feat:` or `fix:` commit)
- [ ] Verify release-please creates PR and release
- [ ] Verify release workflow triggers automatically and builds binaries