### PR TITLE
Add comments explaining TAP_GITHUB_TOKEN requirements

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -14,6 +14,9 @@ jobs:
     # Skip if commit is from the release workflow (avoid loops)
     if: "!startsWith(github.event.head_commit.message, 'chore:') && !startsWith(github.event.head_commit.message, 'chore(')"
     steps:
+      # TAP_GITHUB_TOKEN (a PAT) is required here instead of the default GITHUB_TOKEN
+      # because tag pushes made with GITHUB_TOKEN do not trigger other workflows.
+      # Without this, the Release workflow would not run when we push the tag.
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,6 +89,8 @@ jobs:
             *.tar.gz
             checksums.txt
 
+      # TAP_GITHUB_TOKEN (a PAT) is required to push to the piekstra/homebrew-tap
+      # repository. The default GITHUB_TOKEN only has access to this repository.
       - name: Update Homebrew Cask
         env:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}


### PR DESCRIPTION
## [DOCS]

Add inline comments to workflow files explaining why `TAP_GITHUB_TOKEN` (a PAT) is required:

- **auto-release.yml**: Tag pushes made with `GITHUB_TOKEN` do not trigger other workflows. Without the PAT, the Release workflow would not run.
- **release.yml**: The default `GITHUB_TOKEN` only has access to this repository. A PAT is needed to push to `piekstra/homebrew-tap`.