### PR TITLE
Add Windows builds and migrate to GoReleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,8 @@ permissions:
   contents: write
 
 jobs:
-  release:
-    runs-on: macos-latest
+  goreleaser:
+    runs-on: ubuntu-latest
     env:
       TAG: ${{ github.ref_name || inputs.tag }}
     steps:
@@ -27,67 +27,46 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.21"
+          go-version: "1.22"
 
-      - name: Set build variables
-        id: vars
-        run: |
-          echo "VERSION=${{ env.TAG }}" >> $GITHUB_OUTPUT
-          echo "COMMIT=$(git rev-parse --short HEAD)" >> $GITHUB_OUTPUT
-          echo "DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> $GITHUB_OUTPUT
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build macOS ARM64
+  update-homebrew:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
+    steps:
+      - name: Download checksums from release
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
-          GOOS=darwin GOARCH=arm64 go build -ldflags "-s -w \
-            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
-            -o slack-chat-api ./cmd/slack-chat-api
-          tar -czvf slack-chat-api_${{ env.TAG }}_darwin_arm64.tar.gz slack-chat-api
-          rm slack-chat-api
-
-      - name: Build macOS AMD64
-        run: |
-          GOOS=darwin GOARCH=amd64 go build -ldflags "-s -w \
-            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
-            -o slack-chat-api ./cmd/slack-chat-api
-          tar -czvf slack-chat-api_${{ env.TAG }}_darwin_amd64.tar.gz slack-chat-api
-          rm slack-chat-api
-
-      - name: Build Linux ARM64
-        run: |
-          GOOS=linux GOARCH=arm64 go build -ldflags "-s -w \
-            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
-            -o slack-chat-api ./cmd/slack-chat-api
-          tar -czvf slack-chat-api_${{ env.TAG }}_linux_arm64.tar.gz slack-chat-api
-          rm slack-chat-api
-
-      - name: Build Linux AMD64
-        run: |
-          GOOS=linux GOARCH=amd64 go build -ldflags "-s -w \
-            -X github.com/piekstra/slack-chat-api/internal/version.Version=${{ steps.vars.outputs.VERSION }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Commit=${{ steps.vars.outputs.COMMIT }} \
-            -X github.com/piekstra/slack-chat-api/internal/version.Date=${{ steps.vars.outputs.DATE }}" \
-            -o slack-chat-api ./cmd/slack-chat-api
-          tar -czvf slack-chat-api_${{ env.TAG }}_linux_amd64.tar.gz slack-chat-api
-          rm slack-chat-api
-
-      - name: Generate checksums
-        run: |
-          shasum -a 256 *.tar.gz > checksums.txt
+          gh release download "${{ env.TAG }}" --repo ${{ github.repository }} --pattern "checksums.txt"
           cat checksums.txt
 
-      - name: Upload Release Assets
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ env.TAG }}
-          files: |
-            *.tar.gz
-            checksums.txt
+      - name: Parse checksums
+        id: checksums
+        run: |
+          VERSION="${{ env.TAG }}"
+          VERSION_NUM="${VERSION#v}"
+
+          # GoReleaser checksums.txt format: <hash>  <filename>
+          DARWIN_ARM64_SHA=$(grep "darwin_arm64.tar.gz" checksums.txt | cut -d' ' -f1)
+          DARWIN_AMD64_SHA=$(grep "darwin_amd64.tar.gz" checksums.txt | cut -d' ' -f1)
+          LINUX_ARM64_SHA=$(grep "linux_arm64.tar.gz" checksums.txt | cut -d' ' -f1)
+          LINUX_AMD64_SHA=$(grep "linux_amd64.tar.gz" checksums.txt | cut -d' ' -f1)
+
+          echo "version=${VERSION_NUM}" >> $GITHUB_OUTPUT
+          echo "darwin_arm64_sha=${DARWIN_ARM64_SHA}" >> $GITHUB_OUTPUT
+          echo "darwin_amd64_sha=${DARWIN_AMD64_SHA}" >> $GITHUB_OUTPUT
+          echo "linux_arm64_sha=${LINUX_ARM64_SHA}" >> $GITHUB_OUTPUT
+          echo "linux_amd64_sha=${LINUX_AMD64_SHA}" >> $GITHUB_OUTPUT
 
       # TAP_GITHUB_TOKEN (a PAT) is required to push to the open-cli-collective/homebrew-tap
       # repository. The default GITHUB_TOKEN only has access to this repository.
@@ -95,47 +74,45 @@ jobs:
         env:
           TAP_GITHUB_TOKEN: ${{ secrets.TAP_GITHUB_TOKEN }}
         run: |
-          VERSION="${{ env.TAG }}"
-          VERSION_NUM="${VERSION#v}"
-
-          DARWIN_ARM64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_darwin_arm64.tar.gz | cut -d' ' -f1)
-          DARWIN_AMD64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_darwin_amd64.tar.gz | cut -d' ' -f1)
-          LINUX_ARM64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_linux_arm64.tar.gz | cut -d' ' -f1)
-          LINUX_AMD64_SHA=$(shasum -a 256 slack-chat-api_${{ env.TAG }}_linux_amd64.tar.gz | cut -d' ' -f1)
+          VERSION="${{ steps.checksums.outputs.version }}"
+          DARWIN_ARM64_SHA="${{ steps.checksums.outputs.darwin_arm64_sha }}"
+          DARWIN_AMD64_SHA="${{ steps.checksums.outputs.darwin_amd64_sha }}"
+          LINUX_ARM64_SHA="${{ steps.checksums.outputs.linux_arm64_sha }}"
+          LINUX_AMD64_SHA="${{ steps.checksums.outputs.linux_amd64_sha }}"
 
           git clone https://x-access-token:${TAP_GITHUB_TOKEN}@github.com/open-cli-collective/homebrew-tap.git
           cd homebrew-tap
 
           mkdir -p Casks
 
-          cat > Casks/slack-chat-api.rb << 'CASKEOF'
+          cat > Casks/slack-chat-api.rb << CASKEOF
           cask "slack-chat-api" do
             name "slack-chat-api"
             desc "Command-line interface for Slack"
             homepage "https://github.com/open-cli-collective/slack-chat-api"
-            version "VERSION_PLACEHOLDER"
+            version "${VERSION}"
 
             binary "slack-chat-api"
 
             on_macos do
               on_arm do
                 url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_darwin_arm64.tar.gz"
-                sha256 "DARWIN_ARM64_PLACEHOLDER"
+                sha256 "${DARWIN_ARM64_SHA}"
               end
               on_intel do
                 url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_darwin_amd64.tar.gz"
-                sha256 "DARWIN_AMD64_PLACEHOLDER"
+                sha256 "${DARWIN_AMD64_SHA}"
               end
             end
 
             on_linux do
               on_arm do
                 url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_linux_arm64.tar.gz"
-                sha256 "LINUX_ARM64_PLACEHOLDER"
+                sha256 "${LINUX_ARM64_SHA}"
               end
               on_intel do
                 url "https://github.com/open-cli-collective/slack-chat-api/releases/download/v#{version}/slack-chat-api_v#{version}_linux_amd64.tar.gz"
-                sha256 "LINUX_AMD64_PLACEHOLDER"
+                sha256 "${LINUX_AMD64_SHA}"
               end
             end
 
@@ -153,17 +130,11 @@ jobs:
           end
           CASKEOF
 
-          sed -i '' "s/VERSION_PLACEHOLDER/${VERSION_NUM}/g" Casks/slack-chat-api.rb
-          sed -i '' "s/DARWIN_ARM64_PLACEHOLDER/${DARWIN_ARM64_SHA}/g" Casks/slack-chat-api.rb
-          sed -i '' "s/DARWIN_AMD64_PLACEHOLDER/${DARWIN_AMD64_SHA}/g" Casks/slack-chat-api.rb
-          sed -i '' "s/LINUX_ARM64_PLACEHOLDER/${LINUX_ARM64_SHA}/g" Casks/slack-chat-api.rb
-          sed -i '' "s/LINUX_AMD64_PLACEHOLDER/${LINUX_AMD64_SHA}/g" Casks/slack-chat-api.rb
-
           # Remove old formula if it exists
           rm -f Formula/slack-chat-api.rb
 
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
-          git commit -m "Update slack-chat-api to ${VERSION_NUM}"
+          git commit -m "Update slack-chat-api to ${VERSION}"
           git push

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -14,6 +14,7 @@ builds:
     goos:
       - darwin
       - linux
+      - windows
     goarch:
       - amd64
       - arm64
@@ -25,8 +26,11 @@ builds:
 
 archives:
   - format: tar.gz
-    name_template: >-
-      {{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    format_overrides:
+      - goos: windows
+        format: zip
+    # Preserve v prefix in filename for backward compatibility with Homebrew Cask URLs
+    name_template: "{{ .ProjectName }}_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
       - README.md
@@ -53,22 +57,3 @@ changelog:
       order: 1
     - title: Other
       order: 999
-
-brews:
-  - name: slack-chat-api
-    repository:
-      owner: piekstra
-      name: homebrew-tap
-    directory: Formula
-    homepage: "https://github.com/piekstra/slack-chat-api"
-    description: "Command-line interface for Slack"
-    license: "MIT"
-    install: |
-      bin.install "slack-chat-api"
-    caveats: |
-      To configure slack-chat-api, run:
-        slack-chat-api config set-token <your-slack-api-token>
-
-      Or set the SLACK_API_TOKEN environment variable.
-    test: |
-      assert_match "slack-chat-api", shell_output("#{bin}/slack-chat-api --help")


### PR DESCRIPTION
## Summary

Migrate the release workflow from manual cross-compilation to GoReleaser, adding Windows builds as the foundation for Chocolatey and Winget distribution.

## Changes

### .goreleaser.yaml
- Add `windows` to `goos` list for Windows builds
- Add `format_overrides` to use zip format for Windows (tar.gz for Unix)
- Update `name_template` to preserve `v` prefix for backward compatibility with Homebrew Cask URLs
- Remove unused `brews` section (keeping manual Cask generation to preserve current installation method)

### release.yml
- Replace manual `GOOS/GOARCH` build steps with `goreleaser/goreleaser-action@v6`
- Split into two jobs: `goreleaser` (builds) and `update-homebrew` (Cask update)
- Parse checksums from GoReleaser's `checksums.txt` output
- Switch from macOS to Ubuntu runner (GoReleaser handles cross-compilation)
- Upgrade Go version from 1.21 to 1.22

## Release Assets (after merge)

- `slack-chat-api_v*_darwin_arm64.tar.gz`
- `slack-chat-api_v*_darwin_amd64.tar.gz`
- `slack-chat-api_v*_linux_arm64.tar.gz`
- `slack-chat-api_v*_linux_amd64.tar.gz`
- `slack-chat-api_v*_windows_amd64.zip` (NEW)
- `slack-chat-api_v*_windows_arm64.zip` (NEW)
- `checksums.txt`

## Testing

1. Merge this PR
2. Push a `feat:` or `fix:` commit to trigger auto-release
3. Verify Windows zip files appear in release assets
4. Verify Homebrew Cask is updated in `open-cli-collective/homebrew-tap`

Closes #57