### PR TITLE
Add Chocolatey packaging and workflow

### DIFF
--- a/.github/workflows/chocolatey-publish.yml
+++ b/.github/workflows/chocolatey-publish.yml
@@ -1,0 +1,69 @@
+name: Publish to Chocolatey
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0, without v prefix)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --repo ${{ github.repository }} --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --repo ${{ github.repository }} --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
+        run: |
+          $version = "${{ inputs.version }}"
+
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/slack-chat-api.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
+
+      - name: Pack and push
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,3 +138,59 @@ jobs:
           git add -A
           git commit -m "Update slack-chat-api to ${VERSION}"
           git push
+
+  chocolatey:
+    needs: goreleaser
+    runs-on: windows-latest
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ env.TAG }}" --repo ${{ github.repository }} --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update version and checksums
+        shell: pwsh
+        run: |
+          $version = "${{ env.TAG }}".TrimStart('v')
+
+          # Update version in nuspec
+          $nuspec = 'packaging/chocolatey/slack-chat-api.nuspec'
+          (Get-Content $nuspec) -replace '<version>0.0.0</version>', "<version>$version</version>" | Set-Content $nuspec
+          Write-Host "Updated nuspec to version $version"
+
+          # Inject checksums into install script
+          $script = 'packaging/chocolatey/tools/chocolateyInstall.ps1'
+          $content = Get-Content $script -Raw
+          $content = $content -replace 'CHECKSUM_AMD64_PLACEHOLDER', $env:X64_HASH
+          $content = $content -replace 'CHECKSUM_ARM64_PLACEHOLDER', $env:ARM64_HASH
+          Set-Content $script $content
+          Write-Host "Injected checksums into install script"
+
+      - name: Pack Chocolatey package
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco pack
+          Get-ChildItem *.nupkg
+
+      - name: Push to Chocolatey
+        shell: pwsh
+        run: |
+          cd packaging/chocolatey
+          choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}

--- a/packaging/chocolatey/README.md
+++ b/packaging/chocolatey/README.md
@@ -1,0 +1,73 @@
+# Chocolatey Package for slack-chat-api
+
+This directory contains the Chocolatey package definition for slack-chat-api.
+
+## Package Structure
+
+```
+packaging/chocolatey/
+├── slack-chat-api.nuspec          # Package metadata
+├── tools/
+│   ├── chocolateyInstall.ps1      # Install script
+│   └── chocolateyUninstall.ps1    # Uninstall script
+└── README.md                       # This file
+```
+
+## How It Works
+
+1. **Release Workflow**: When a new version is released, the GitHub Actions workflow:
+   - Downloads `checksums.txt` from the release
+   - Injects the Windows checksums into `chocolateyInstall.ps1`
+   - Updates the version in `slack-chat-api.nuspec`
+   - Packs and pushes to Chocolatey
+
+2. **Checksum Placeholders**: The install script uses placeholders that are replaced at build time:
+   - `CHECKSUM_AMD64_PLACEHOLDER` → SHA256 of Windows x64 zip
+   - `CHECKSUM_ARM64_PLACEHOLDER` → SHA256 of Windows ARM64 zip
+
+3. **Architecture Detection**: The install script automatically detects:
+   - ARM64 Windows → Downloads `windows_arm64.zip`
+   - x64 Windows → Downloads `windows_amd64.zip`
+   - 32-bit Windows → Throws an error (not supported)
+
+## Manual Publishing
+
+If automated publishing fails, use the manual workflow:
+
+```bash
+gh workflow run chocolatey-publish.yml -f version=X.Y.Z
+```
+
+Or via the GitHub Actions UI: Actions → "Publish to Chocolatey" → Run workflow
+
+## Required Secrets
+
+- `CHOCOLATEY_API_KEY`: API key from https://community.chocolatey.org/account
+
+## Local Testing
+
+To test the package locally:
+
+```powershell
+# Pack the package (creates .nupkg file)
+choco pack
+
+# Install locally for testing
+choco install slack-chat-api -s . -y
+
+# Verify installation
+slack-chat-api --version
+
+# Uninstall
+choco uninstall slack-chat-api -y
+```
+
+## Moderation Notes
+
+Chocolatey has automated moderation. Key rules followed:
+
+- **CPMR0041**: `projectUrl` uses `#readme` suffix to differ from `projectSourceUrl`
+- **CPMR0055**: Only uses `Install-ChocolateyZipPackage` (no custom downloaders)
+- **CPMR0073**: Checksums are required and injected at build time
+
+First submissions typically take 1-3 days for human review. Subsequent versions are usually auto-approved.

--- a/packaging/chocolatey/slack-chat-api.nuspec
+++ b/packaging/chocolatey/slack-chat-api.nuspec
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
+  <metadata>
+    <id>slack-chat-api</id>
+    <version>0.0.0</version>
+    <title>Slack Chat API CLI</title>
+    <authors>Open CLI Collective</authors>
+    <owners>rianjs</owners>
+    <licenseUrl>https://github.com/open-cli-collective/slack-chat-api/blob/main/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/open-cli-collective/slack-chat-api#readme</projectUrl>
+    <projectSourceUrl>https://github.com/open-cli-collective/slack-chat-api</projectSourceUrl>
+    <packageSourceUrl>https://github.com/open-cli-collective/slack-chat-api/tree/main/packaging/chocolatey</packageSourceUrl>
+    <bugTrackerUrl>https://github.com/open-cli-collective/slack-chat-api/issues</bugTrackerUrl>
+    <copyright>Copyright (c) 2025 Open CLI Collective</copyright>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>A lightweight command-line interface for interacting with the Slack Web API. Provides direct API access for automation and scripting.
+
+Features:
+- Send messages to channels and threads
+- Manage channels (create, archive, set topic/purpose)
+- List and search users
+- View message history and reactions
+- Search messages and files (with user token)
+- Secure credential storage (Windows Credential Manager)
+
+Binary: slack-chat-api.exe</description>
+    <summary>Command-line interface for Slack Web API</summary>
+    <releaseNotes>https://github.com/open-cli-collective/slack-chat-api/releases</releaseNotes>
+    <tags>slack cli api messaging automation chat</tags>
+  </metadata>
+  <files>
+    <file src="tools\**" target="tools" />
+  </files>
+</package>

--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -1,0 +1,40 @@
+$ErrorActionPreference = 'Stop'
+
+$version = $env:ChocolateyPackageVersion
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+# Checksums injected by release workflow - DO NOT EDIT MANUALLY
+$checksumAmd64 = 'CHECKSUM_AMD64_PLACEHOLDER'
+$checksumArm64 = 'CHECKSUM_ARM64_PLACEHOLDER'
+
+# Architecture detection with ARM64 support
+if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
+    $arch = 'arm64'
+    $checksum = $checksumArm64
+} elseif ([Environment]::Is64BitOperatingSystem) {
+    $arch = 'amd64'
+    $checksum = $checksumAmd64
+} else {
+    throw "32-bit Windows is not supported. slack-chat-api requires 64-bit Windows."
+}
+
+$baseUrl = "https://github.com/open-cli-collective/slack-chat-api/releases/download/v${version}"
+$zipFile = "slack-chat-api_v${version}_windows_${arch}.zip"
+$url = "${baseUrl}/${zipFile}"
+
+Write-Host "Installing slack-chat-api ${version} for Windows ${arch}..."
+Write-Host "URL: ${url}"
+Write-Host "Checksum (SHA256): ${checksum}"
+
+Install-ChocolateyZipPackage -PackageName $env:ChocolateyPackageName `
+    -Url $url `
+    -UnzipLocation $toolsDir `
+    -Checksum $checksum `
+    -ChecksumType 'sha256'
+
+# Exclude non-executables from shimming
+# Chocolatey auto-creates shims for .exe files; .ignore files prevent shimming other files
+New-Item "$toolsDir\LICENSE.ignore" -Type File -Force | Out-Null
+New-Item "$toolsDir\README.md.ignore" -Type File -Force | Out-Null
+
+Write-Host "slack-chat-api installed successfully. Run 'slack-chat-api --help' to get started."

--- a/packaging/chocolatey/tools/chocolateyUninstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyUninstall.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = 'Stop'
+
+$toolsDir = Split-Path -Parent $MyInvocation.MyCommand.Definition
+
+Write-Host "Uninstalling slack-chat-api..."
+
+# Remove extracted files
+Remove-Item "$toolsDir\slack-chat-api.exe" -Force -ErrorAction SilentlyContinue
+Remove-Item "$toolsDir\LICENSE" -Force -ErrorAction SilentlyContinue
+Remove-Item "$toolsDir\README.md" -Force -ErrorAction SilentlyContinue
+
+# Remove .ignore files created during install
+Remove-Item "$toolsDir\*.ignore" -Force -ErrorAction SilentlyContinue
+
+Write-Host "slack-chat-api has been uninstalled."


### PR DESCRIPTION
## Summary

Add Chocolatey package distribution for Windows users. After this is merged and a release is triggered, users can install via `choco install slack-chat-api`.

## Changes

### New Files

**packaging/chocolatey/**
- `slack-chat-api.nuspec` - Package metadata (follows CPMR0041 with `#readme` suffix)
- `tools/chocolateyInstall.ps1` - Install script with checksum placeholders and ARM64 support
- `tools/chocolateyUninstall.ps1` - Cleanup script
- `README.md` - Maintainer documentation

**Workflows**
- Updated `release.yml` with `chocolatey` job that runs after `goreleaser`
- Added `chocolatey-publish.yml` for manual retries

### Chocolatey Compliance

- **CPMR0041**: `projectUrl` uses `#readme` suffix to differ from `projectSourceUrl`
- **CPMR0055**: Uses `Install-ChocolateyZipPackage` (no custom downloaders)
- **CPMR0073**: Checksums injected from `checksums.txt` at build time

## Required Secrets

Before the first release, add this secret to the repository:
- `CHOCOLATEY_API_KEY` - Obtain from https://community.chocolatey.org/account

## Verification

1. Merge this PR
2. Trigger a release (push a `feat:` or `fix:` commit)
3. Check Chocolatey moderation queue for the package
4. First submission takes 1-3 days for human review
5. After approval: `choco install slack-chat-api`

Closes #58