### PR TITLE
Add Winget packaging and workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -194,3 +194,104 @@ jobs:
         run: |
           cd packaging/chocolatey
           choco push (Get-ChildItem *.nupkg).Name --source https://push.chocolatey.org/ --key ${{ secrets.CHOCOLATEY_API_KEY }}
+
+  winget:
+    needs: goreleaser
+    runs-on: windows-latest
+    env:
+      TAG: ${{ github.ref_name || inputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
+        run: |
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/slack-chat-api" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will use wingetcreate submit"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "${{ env.TAG }}" --repo ${{ github.repository }} --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
+        shell: pwsh
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $version = "${{ env.TAG }}".TrimStart('v')
+          $x64 = "https://github.com/open-cli-collective/slack-chat-api/releases/download/${{ env.TAG }}/slack-chat-api_v${version}_windows_amd64.zip"
+          $arm64 = "https://github.com/open-cli-collective/slack-chat-api/releases/download/${{ env.TAG }}/slack-chat-api_v${version}_windows_arm64.zip"
+
+          Write-Host "Updating existing manifest to version $version"
+          Write-Host "x64 URL: $x64"
+          Write-Host "arm64 URL: $arm64"
+          ./wingetcreate.exe update OpenCLICollective.slack-chat-api --version $version --urls $x64 $arm64 --submit --token $env:WINGET_GITHUB_TOKEN
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $version = "${{ env.TAG }}".TrimStart('v')
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.slack-chat-api.yaml" $versionManifest
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.slack-chat-api.locale.en-US.yaml" $localeManifest
+
+          # Update installer manifest with version and real checksums
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          # Use .NET regex for sequential replacement (PowerShell -replace doesn't support count)
+          $regex = [regex]"0{64}"
+          $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
+          $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
+          Set-Content "$manifestDir/OpenCLICollective.slack-chat-api.installer.yaml" $installerManifest
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token $env:WINGET_GITHUB_TOKEN $manifestDir

--- a/.github/workflows/test-winget.yml
+++ b/.github/workflows/test-winget.yml
@@ -1,0 +1,55 @@
+name: Test Winget Manifest
+
+on:
+  pull_request:
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packaging/winget/**'
+      - '.github/workflows/test-winget.yml'
+
+jobs:
+  validate-winget:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate manifest schema
+        shell: pwsh
+        run: |
+          $testDir = "winget-validate-test"
+          $testVersion = "0.0.1"
+          $testHash1 = "0000000000000000000000000000000000000000000000000000000000000001"
+          $testHash2 = "0000000000000000000000000000000000000000000000000000000000000002"
+
+          New-Item -ItemType Directory -Path $testDir -Force | Out-Null
+
+          # Read and process actual template files
+          $content = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.slack-chat-api.yaml" $content -Encoding UTF8
+
+          $content = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.locale.en-US.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          Set-Content "$testDir/OpenCLICollective.slack-chat-api.locale.en-US.yaml" $content -Encoding UTF8
+
+          $content = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.installer.yaml" -Raw
+          $content = $content -replace "0\.0\.0", $testVersion
+          $regex = [regex]"0{64}"
+          $content = $regex.Replace($content, $testHash1, 1)
+          $content = $regex.Replace($content, $testHash2, 1)
+          Set-Content "$testDir/OpenCLICollective.slack-chat-api.installer.yaml" $content -Encoding UTF8
+
+          Write-Host "Generated test manifests in $testDir"
+          Get-ChildItem $testDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating winget manifest schema..."
+          winget validate --manifest $testDir/
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest schema validation failed"
+            exit 1
+          }
+          Write-Host "Manifest schema validation passed!"

--- a/.github/workflows/winget-publish.yml
+++ b/.github/workflows/winget-publish.yml
@@ -1,0 +1,117 @@
+name: Publish to Winget
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to publish (e.g., 1.0.0, without v prefix)'
+        required: true
+        type: string
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate release exists
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          $release = gh release view "v${{ inputs.version }}" --repo ${{ github.repository }} --json tagName 2>&1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Release v${{ inputs.version }} not found"
+            exit 1
+          }
+          Write-Host "Found release v${{ inputs.version }}"
+
+      - name: Install wingetcreate
+        shell: pwsh
+        run: |
+          Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+
+      - name: Check if manifest exists in winget-pkgs
+        id: check-manifest
+        shell: pwsh
+        run: |
+          $response = Invoke-WebRequest -Uri "https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/o/OpenCLICollective/slack-chat-api" -Method Head -SkipHttpErrorCheck
+          if ($response.StatusCode -eq 200) {
+            Write-Host "Manifest exists - will use wingetcreate update"
+            echo "exists=true" >> $env:GITHUB_OUTPUT
+          } else {
+            Write-Host "Manifest does not exist - will use wingetcreate submit"
+            echo "exists=false" >> $env:GITHUB_OUTPUT
+          }
+
+      - name: Get checksums from release
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download "v${{ inputs.version }}" --repo ${{ github.repository }} --pattern "checksums.txt" --dir .
+
+          $checksums = Get-Content checksums.txt
+          $x64Hash = ($checksums | Select-String "windows_amd64.zip").Line.Split()[0]
+          $arm64Hash = ($checksums | Select-String "windows_arm64.zip").Line.Split()[0]
+
+          Write-Host "x64 SHA256: $x64Hash"
+          Write-Host "arm64 SHA256: $arm64Hash"
+
+          echo "X64_HASH=$x64Hash" >> $env:GITHUB_ENV
+          echo "ARM64_HASH=$arm64Hash" >> $env:GITHUB_ENV
+
+      - name: Update manifest (existing package)
+        if: steps.check-manifest.outputs.exists == 'true'
+        shell: pwsh
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $version = "${{ inputs.version }}"
+          $x64 = "https://github.com/open-cli-collective/slack-chat-api/releases/download/v${version}/slack-chat-api_v${version}_windows_amd64.zip"
+          $arm64 = "https://github.com/open-cli-collective/slack-chat-api/releases/download/v${version}/slack-chat-api_v${version}_windows_arm64.zip"
+
+          Write-Host "Updating existing manifest to version $version"
+          ./wingetcreate.exe update OpenCLICollective.slack-chat-api --version $version --urls $x64 $arm64 --submit --token $env:WINGET_GITHUB_TOKEN
+
+      - name: Create manifest (new package)
+        if: steps.check-manifest.outputs.exists == 'false'
+        shell: pwsh
+        env:
+          WINGET_GITHUB_TOKEN: ${{ secrets.WINGET_GITHUB_TOKEN }}
+        run: |
+          $version = "${{ inputs.version }}"
+          $manifestDir = "manifests"
+          New-Item -ItemType Directory -Path $manifestDir -Force | Out-Null
+
+          # Update version manifest
+          $versionManifest = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.yaml" -Raw
+          $versionManifest = $versionManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.slack-chat-api.yaml" $versionManifest
+
+          # Update locale manifest
+          $localeManifest = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.locale.en-US.yaml" -Raw
+          $localeManifest = $localeManifest -replace "0\.0\.0", $version
+          Set-Content "$manifestDir/OpenCLICollective.slack-chat-api.locale.en-US.yaml" $localeManifest
+
+          # Update installer manifest with version and real checksums
+          $installerManifest = Get-Content "packaging/winget/OpenCLICollective.slack-chat-api.installer.yaml" -Raw
+          $installerManifest = $installerManifest -replace "0\.0\.0", $version
+          $regex = [regex]"0{64}"
+          $installerManifest = $regex.Replace($installerManifest, $env:X64_HASH, 1)
+          $installerManifest = $regex.Replace($installerManifest, $env:ARM64_HASH, 1)
+          Set-Content "$manifestDir/OpenCLICollective.slack-chat-api.installer.yaml" $installerManifest
+
+          Write-Host "Generated manifests:"
+          Get-ChildItem $manifestDir | ForEach-Object { Write-Host "  $_" }
+
+          Write-Host "`nValidating manifests..."
+          winget validate --manifest $manifestDir
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Manifest validation failed"
+            exit 1
+          }
+          Write-Host "Validation passed!"
+
+          Write-Host "`nSubmitting new package to Winget..."
+          ./wingetcreate.exe submit --token $env:WINGET_GITHUB_TOKEN $manifestDir

--- a/packaging/winget/OpenCLICollective.slack-chat-api.installer.yaml
+++ b/packaging/winget/OpenCLICollective.slack-chat-api.installer.yaml
@@ -1,0 +1,18 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.installer.1.10.0.schema.json
+
+PackageIdentifier: OpenCLICollective.slack-chat-api
+PackageVersion: 0.0.0
+InstallerType: zip
+NestedInstallerType: portable
+NestedInstallerFiles:
+  - RelativeFilePath: slack-chat-api.exe
+    PortableCommandAlias: slack-chat-api
+Installers:
+  - Architecture: x64
+    InstallerUrl: https://github.com/open-cli-collective/slack-chat-api/releases/download/v0.0.0/slack-chat-api_v0.0.0_windows_amd64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+  - Architecture: arm64
+    InstallerUrl: https://github.com/open-cli-collective/slack-chat-api/releases/download/v0.0.0/slack-chat-api_v0.0.0_windows_arm64.zip
+    InstallerSha256: 0000000000000000000000000000000000000000000000000000000000000000
+ManifestType: installer
+ManifestVersion: 1.10.0

--- a/packaging/winget/OpenCLICollective.slack-chat-api.locale.en-US.yaml
+++ b/packaging/winget/OpenCLICollective.slack-chat-api.locale.en-US.yaml
@@ -1,0 +1,26 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.10.0.schema.json
+
+PackageIdentifier: OpenCLICollective.slack-chat-api
+PackageVersion: 0.0.0
+PackageLocale: en-US
+Publisher: Open CLI Collective
+PublisherUrl: https://github.com/open-cli-collective
+PackageName: Slack Chat API CLI
+PackageUrl: https://github.com/open-cli-collective/slack-chat-api
+License: MIT
+LicenseUrl: https://github.com/open-cli-collective/slack-chat-api/blob/main/LICENSE
+ShortDescription: Command-line interface for Slack Web API
+Description: |-
+  A lightweight CLI for interacting with the Slack Web API. Provides direct
+  API access for automation and scripting including sending messages, managing
+  channels, listing users, viewing message history, and searching messages/files.
+Tags:
+  - slack
+  - cli
+  - api
+  - messaging
+  - automation
+  - chat
+ReleaseNotesUrl: https://github.com/open-cli-collective/slack-chat-api/releases
+ManifestType: defaultLocale
+ManifestVersion: 1.10.0

--- a/packaging/winget/OpenCLICollective.slack-chat-api.yaml
+++ b/packaging/winget/OpenCLICollective.slack-chat-api.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://aka.ms/winget-manifest.version.1.10.0.schema.json
+
+PackageIdentifier: OpenCLICollective.slack-chat-api
+PackageVersion: 0.0.0
+DefaultLocale: en-US
+ManifestType: version
+ManifestVersion: 1.10.0

--- a/packaging/winget/README.md
+++ b/packaging/winget/README.md
@@ -1,0 +1,77 @@
+# Winget Package for slack-chat-api
+
+This directory contains the Winget manifest templates for slack-chat-api.
+
+## Package Structure
+
+```
+packaging/winget/
+├── OpenCLICollective.slack-chat-api.yaml              # Version manifest
+├── OpenCLICollective.slack-chat-api.installer.yaml    # Installer manifest
+├── OpenCLICollective.slack-chat-api.locale.en-US.yaml # Locale manifest
+└── README.md                                           # This file
+```
+
+## How It Works
+
+Unlike Chocolatey (direct push), Winget uses **pull requests** to microsoft/winget-pkgs:
+
+1. **Release Workflow**: When a new version is released, the GitHub Actions workflow:
+   - Checks if the package already exists in winget-pkgs
+   - **For updates**: Uses `wingetcreate update` with new URLs
+   - **For new packages**: Processes templates with version/checksums and uses `wingetcreate submit`
+   - Creates a PR to microsoft/winget-pkgs
+
+2. **Microsoft Validation**: Automated validation runs on the PR
+3. **Auto-merge**: On success, PRs are typically auto-merged within minutes
+4. **Availability**: Users can install immediately after merge
+
+## Manifest Templates
+
+The manifest files use placeholders:
+- `0.0.0` → Replaced with actual version
+- 64 zeros → Replaced with SHA256 checksums (x64 first, then arm64)
+
+## Package Identifier
+
+```
+OpenCLICollective.slack-chat-api
+```
+
+Manifests are stored at: `manifests/o/OpenCLICollective/slack-chat-api/`
+
+## Manual Publishing
+
+If automated publishing fails, use the manual workflow:
+
+```bash
+gh workflow run winget-publish.yml -f version=X.Y.Z
+```
+
+Or via the GitHub Actions UI: Actions → "Publish to Winget" → Run workflow
+
+## Required Secrets
+
+- `WINGET_GITHUB_TOKEN`: PAT with `public_repo` scope for creating PRs to microsoft/winget-pkgs
+
+## Local Validation
+
+To validate manifests locally:
+
+```powershell
+# Create a test directory with processed manifests
+$testDir = "winget-test"
+New-Item -ItemType Directory -Path $testDir -Force
+
+# Copy and update manifests (replace placeholders with test values)
+# ... see test-winget.yml for full example ...
+
+# Validate
+winget validate --manifest $testDir/
+```
+
+## Installation (after package is approved)
+
+```powershell
+winget install OpenCLICollective.slack-chat-api
+```


### PR DESCRIPTION
## Summary

Add Winget package distribution for Windows users. After this is merged and a release is triggered, users can install via `winget install OpenCLICollective.slack-chat-api`.

## Changes

### New Files

**packaging/winget/**
- `OpenCLICollective.slack-chat-api.yaml` - Version manifest (schema 1.10.0)
- `OpenCLICollective.slack-chat-api.installer.yaml` - Installer manifest with x64/arm64
- `OpenCLICollective.slack-chat-api.locale.en-US.yaml` - Locale manifest
- `README.md` - Maintainer documentation

**Workflows**
- Updated `release.yml` with `winget` job that:
  - Detects if package exists in winget-pkgs (new vs update)
  - For updates: Uses `wingetcreate update`
  - For new: Processes templates and uses `wingetcreate submit`
- Added `winget-publish.yml` for manual retries
- Added `test-winget.yml` for manifest validation on PRs

### How Winget Publishing Works

Unlike Chocolatey (direct push), Winget uses PRs to microsoft/winget-pkgs:
1. Workflow generates manifests with version/checksums
2. `wingetcreate submit` creates PR to microsoft/winget-pkgs
3. Microsoft's automated validation runs
4. On success: Auto-merged within minutes

## Required Secrets

Before the first release, add this secret to the repository:
- `WINGET_GITHUB_TOKEN` - PAT with `public_repo` scope for creating PRs to microsoft/winget-pkgs

## Verification

1. Merge this PR
2. Trigger a release (push a `feat:` or `fix:` commit)
3. Check for new PR on microsoft/winget-pkgs
4. After merge: `winget install OpenCLICollective.slack-chat-api`

Closes #59