### PR TITLE
ci: add path filter and stricter commit filter to auto-release

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -4,6 +4,11 @@ on:
   push:
     branches:
       - main
+    # Gate 1: Only trigger when Go code actually changes
+    paths:
+      - '**.go'
+      - 'go.mod'
+      - 'go.sum'
 
 permissions:
   contents: write
@@ -11,8 +16,12 @@ permissions:
 jobs:
   create-release:
     runs-on: ubuntu-latest
-    # Skip if commit is from the release workflow (avoid loops)
-    if: "!startsWith(github.event.head_commit.message, 'chore:') && !startsWith(github.event.head_commit.message, 'chore(')"
+    # Gate 2: Only release for feat: and fix: commits (actual functionality changes)
+    if: >-
+      startsWith(github.event.head_commit.message, 'feat:') ||
+      startsWith(github.event.head_commit.message, 'feat(') ||
+      startsWith(github.event.head_commit.message, 'fix:') ||
+      startsWith(github.event.head_commit.message, 'fix(')
     steps:
       # TAP_GITHUB_TOKEN (a PAT) is required here instead of the default GITHUB_TOKEN
       # because tag pushes made with GITHUB_TOKEN do not trigger other workflows.


### PR DESCRIPTION
## Summary
- Add path filter to only trigger on Go code changes (`**.go`, `go.mod`, `go.sum`)
- Change commit filter from "not chore:" to "feat: or fix: only"

This aligns with the confluence-cli pattern for stricter release gating.

Closes #67