### PR TITLE
docs: add commit conventions and release workflow to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,3 +126,40 @@ The `internal/client` package wraps the Slack API:
 - `github.com/slack-go/slack` - Slack API client
 - `github.com/spf13/cobra` - CLI framework
 - `github.com/zalando/go-keyring` - Cross-platform keychain
+
+## Commit Conventions
+
+Use conventional commits:
+
+```
+type(scope): description
+
+feat(channels): add archive command
+fix(messages): handle rate limiting
+docs(readme): add configuration examples
+```
+
+| Prefix | Purpose | Triggers Release? |
+|--------|---------|-------------------|
+| `feat:` | New features | Yes |
+| `fix:` | Bug fixes | Yes |
+| `docs:` | Documentation only | No |
+| `test:` | Adding/updating tests | No |
+| `refactor:` | Code changes that don't fix bugs or add features | No |
+| `chore:` | Maintenance tasks | No |
+| `ci:` | CI/CD changes | No |
+
+## CI & Release Workflow
+
+Releases are automated with a dual-gate system to avoid unnecessary releases:
+
+**Gate 1 - Path filter:** Only triggers when Go code changes (`**.go`, `go.mod`, `go.sum`)
+**Gate 2 - Commit prefix:** Only `feat:` and `fix:` commits create releases
+
+This means:
+- `feat: add command` + Go files changed → release
+- `fix: handle edge case` + Go files changed → release
+- `docs:`, `ci:`, `test:`, `refactor:` → no release
+- Changes only to docs, packaging, workflows → no release
+
+**After merging a release-triggering PR:** The workflow creates a tag, which triggers GoReleaser to build binaries and publish to Homebrew. Chocolatey and Winget require manual workflow dispatch.


### PR DESCRIPTION
## Summary
- Add Commit Conventions section with prefix table
- Add CI & Release Workflow section explaining the dual-gate system

Closes #69