### PR TITLE
chore: migrate module path from piekstra to open-cli-collective

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -30,7 +30,7 @@ formatters:
   settings:
     goimports:
       local-prefixes:
-        - github.com/piekstra/slack-cli
+        - github.com/open-cli-collective/slack-chat-api
 
 run:
   timeout: 5m

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -20,9 +20,9 @@ builds:
       - arm64
     ldflags:
       - -s -w
-      - -X github.com/piekstra/slack-chat-api/internal/version.Version={{.Version}}
-      - -X github.com/piekstra/slack-chat-api/internal/version.Commit={{.Commit}}
-      - -X github.com/piekstra/slack-chat-api/internal/version.Date={{.Date}}
+      - -X github.com/open-cli-collective/slack-chat-api/internal/version.Version={{.Version}}
+      - -X github.com/open-cli-collective/slack-chat-api/internal/version.Commit={{.Commit}}
+      - -X github.com/open-cli-collective/slack-chat-api/internal/version.Date={{.Date}}
 
 archives:
   - format: tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,27 +4,27 @@
 
 ### Features
 
-* Enhanced search capabilities: user search, scope filters, query builder flags ([#48](https://github.com/piekstra/slack-chat-api/pull/48))
-* Replace release-please with auto-release on merge ([#45](https://github.com/piekstra/slack-chat-api/pull/45))
+* Enhanced search capabilities: user search, scope filters, query builder flags ([#48](https://github.com/open-cli-collective/slack-chat-api/pull/48))
+* Replace release-please with auto-release on merge ([#45](https://github.com/open-cli-collective/slack-chat-api/pull/45))
 
 ### Bug Fixes
 
-* Unescape shell-escaped exclamation marks in message text ([#47](https://github.com/piekstra/slack-chat-api/pull/47))
-* Use PAT for release-please to trigger release workflow ([#43](https://github.com/piekstra/slack-chat-api/pull/43))
+* Unescape shell-escaped exclamation marks in message text ([#47](https://github.com/open-cli-collective/slack-chat-api/pull/47))
+* Use PAT for release-please to trigger release workflow ([#43](https://github.com/open-cli-collective/slack-chat-api/pull/43))
 
 ### Other Changes
 
-* Update remaining docs to use slack-chat-api ([#46](https://github.com/piekstra/slack-chat-api/pull/46))
+* Update remaining docs to use slack-chat-api ([#46](https://github.com/open-cli-collective/slack-chat-api/pull/46))
 
-## [3.0.1](https://github.com/piekstra/slack-chat-api/compare/v3.0.0...v3.0.1) (2026-01-12)
+## [3.0.1](https://github.com/open-cli-collective/slack-chat-api/compare/v3.0.0...v3.0.1) (2026-01-12)
 
 
 ### Bug Fixes
 
-* Add ldflags to release builds and auto-merge release PRs ([#39](https://github.com/piekstra/slack-chat-api/issues/39)) ([352a3f1](https://github.com/piekstra/slack-chat-api/commit/352a3f1c42e889f0a1957948fa9c44d6c414b3d0))
-* Extract PR number from JSON output for auto-merge ([#41](https://github.com/piekstra/slack-chat-api/issues/41)) ([95fce10](https://github.com/piekstra/slack-chat-api/commit/95fce10aed7c8618040e51409a66b48a3bfc2281))
+* Add ldflags to release builds and auto-merge release PRs ([#39](https://github.com/open-cli-collective/slack-chat-api/issues/39)) ([352a3f1](https://github.com/open-cli-collective/slack-chat-api/commit/352a3f1c42e889f0a1957948fa9c44d6c414b3d0))
+* Extract PR number from JSON output for auto-merge ([#41](https://github.com/open-cli-collective/slack-chat-api/issues/41)) ([95fce10](https://github.com/open-cli-collective/slack-chat-api/commit/95fce10aed7c8618040e51409a66b48a3bfc2281))
 
-## [3.0.0](https://github.com/piekstra/slack-chat-api/compare/v2.1.0...v3.0.0) (2026-01-12)
+## [3.0.0](https://github.com/open-cli-collective/slack-chat-api/compare/v2.1.0...v3.0.0) (2026-01-12)
 
 
 ### ⚠ BREAKING CHANGES
@@ -37,16 +37,16 @@
 
 ### Features
 
-* Rename project from slack-chat-api to slack-chat-api ([#37](https://github.com/piekstra/slack-chat-api/issues/37)) ([b03b09e](https://github.com/piekstra/slack-chat-api/commit/b03b09e794f0a41c6f2b1dc1ceed316cebde3b50))
+* Rename project from slack-chat-api to slack-chat-api ([#37](https://github.com/open-cli-collective/slack-chat-api/issues/37)) ([b03b09e](https://github.com/open-cli-collective/slack-chat-api/commit/b03b09e794f0a41c6f2b1dc1ceed316cebde3b50))
 
-## [2.1.0](https://github.com/piekstra/slack-chat-api/compare/v2.0.0...v2.1.0) (2026-01-12)
+## [2.1.0](https://github.com/open-cli-collective/slack-chat-api/compare/v2.0.0...v2.1.0) (2026-01-12)
 
 
 ### Features
 
-* Add Slack search functionality with dual token support ([#31](https://github.com/piekstra/slack-chat-api/issues/31)) ([00c28f9](https://github.com/piekstra/slack-chat-api/commit/00c28f9f50127b072cec2dfec8044ff31d05dc8f))
+* Add Slack search functionality with dual token support ([#31](https://github.com/open-cli-collective/slack-chat-api/issues/31)) ([00c28f9](https://github.com/open-cli-collective/slack-chat-api/commit/00c28f9f50127b072cec2dfec8044ff31d05dc8f))
 
-## [2.0.0](https://github.com/piekstra/slack-chat-api/compare/v1.2.0...v2.0.0) (2026-01-12)
+## [2.0.0](https://github.com/open-cli-collective/slack-chat-api/compare/v1.2.0...v2.0.0) (2026-01-12)
 
 
 ### ⚠ BREAKING CHANGES
@@ -55,16 +55,16 @@
 
 ### Features
 
-* Add --output flag and consistent output formatting (Phase 4) ([#15](https://github.com/piekstra/slack-chat-api/issues/15)) ([574008b](https://github.com/piekstra/slack-chat-api/commit/574008b5ee5a87abd39af0bd6d8108474421b151))
-* Add Claude Code AI agent configuration ([#18](https://github.com/piekstra/slack-chat-api/issues/18)) ([eb05acb](https://github.com/piekstra/slack-chat-api/commit/eb05acb9052d89455252bf37e042e2a8c139f3f3)), closes [#7](https://github.com/piekstra/slack-chat-api/issues/7)
-* Add config test command and document 1Password integration ([#22](https://github.com/piekstra/slack-chat-api/issues/22)) ([#23](https://github.com/piekstra/slack-chat-api/issues/23)) ([72fd833](https://github.com/piekstra/slack-chat-api/commit/72fd833bd44cfbb9b86092900ac082d814aac705))
-* Add input validation, stdin support, and --force flag ([#19](https://github.com/piekstra/slack-chat-api/issues/19)) ([413865a](https://github.com/piekstra/slack-chat-api/commit/413865aa2612be0b5138bb3b891e190d59672767)), closes [#8](https://github.com/piekstra/slack-chat-api/issues/8)
-* Add internal/version package for build-time version info ([cf5613e](https://github.com/piekstra/slack-chat-api/commit/cf5613ec682bd16ae79aaba6c76e3d5e9a46008b))
-* Update root command to use version package ([90b6d95](https://github.com/piekstra/slack-chat-api/commit/90b6d9546eb0e15c21213ed7b5df448b8f01661e))
+* Add --output flag and consistent output formatting (Phase 4) ([#15](https://github.com/open-cli-collective/slack-chat-api/issues/15)) ([574008b](https://github.com/open-cli-collective/slack-chat-api/commit/574008b5ee5a87abd39af0bd6d8108474421b151))
+* Add Claude Code AI agent configuration ([#18](https://github.com/open-cli-collective/slack-chat-api/issues/18)) ([eb05acb](https://github.com/open-cli-collective/slack-chat-api/commit/eb05acb9052d89455252bf37e042e2a8c139f3f3)), closes [#7](https://github.com/open-cli-collective/slack-chat-api/issues/7)
+* Add config test command and document 1Password integration ([#22](https://github.com/open-cli-collective/slack-chat-api/issues/22)) ([#23](https://github.com/open-cli-collective/slack-chat-api/issues/23)) ([72fd833](https://github.com/open-cli-collective/slack-chat-api/commit/72fd833bd44cfbb9b86092900ac082d814aac705))
+* Add input validation, stdin support, and --force flag ([#19](https://github.com/open-cli-collective/slack-chat-api/issues/19)) ([413865a](https://github.com/open-cli-collective/slack-chat-api/commit/413865aa2612be0b5138bb3b891e190d59672767)), closes [#8](https://github.com/open-cli-collective/slack-chat-api/issues/8)
+* Add internal/version package for build-time version info ([cf5613e](https://github.com/open-cli-collective/slack-chat-api/commit/cf5613ec682bd16ae79aaba6c76e3d5e9a46008b))
+* Update root command to use version package ([90b6d95](https://github.com/open-cli-collective/slack-chat-api/commit/90b6d9546eb0e15c21213ed7b5df448b8f01661e))
 
 
 ### Bug Fixes
 
-* Add helpful error for unarchive limitation ([#26](https://github.com/piekstra/slack-chat-api/issues/26)) ([#29](https://github.com/piekstra/slack-chat-api/issues/29)) ([e904f11](https://github.com/piekstra/slack-chat-api/commit/e904f112037a91074aa06b5276d6e2ce4ae885ca))
-* Handle token source correctly in config commands ([#25](https://github.com/piekstra/slack-chat-api/issues/25)) ([#28](https://github.com/piekstra/slack-chat-api/issues/28)) ([90fb754](https://github.com/piekstra/slack-chat-api/commit/90fb75456c1955d5c3c68d6335c6c4db480e6014))
-* Respect --limit flag in channels/users list ([#24](https://github.com/piekstra/slack-chat-api/issues/24)) ([#27](https://github.com/piekstra/slack-chat-api/issues/27)) ([2168989](https://github.com/piekstra/slack-chat-api/commit/21689893d65bfd10ec8488e0dc3432cfae70da71))
+* Add helpful error for unarchive limitation ([#26](https://github.com/open-cli-collective/slack-chat-api/issues/26)) ([#29](https://github.com/open-cli-collective/slack-chat-api/issues/29)) ([e904f11](https://github.com/open-cli-collective/slack-chat-api/commit/e904f112037a91074aa06b5276d6e2ce4ae885ca))
+* Handle token source correctly in config commands ([#25](https://github.com/open-cli-collective/slack-chat-api/issues/25)) ([#28](https://github.com/open-cli-collective/slack-chat-api/issues/28)) ([90fb754](https://github.com/open-cli-collective/slack-chat-api/commit/90fb75456c1955d5c3c68d6335c6c4db480e6014))
+* Respect --limit flag in channels/users list ([#24](https://github.com/open-cli-collective/slack-chat-api/issues/24)) ([#27](https://github.com/open-cli-collective/slack-chat-api/issues/27)) ([2168989](https://github.com/open-cli-collective/slack-chat-api/commit/21689893d65bfd10ec8488e0dc3432cfae70da71))

--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,9 @@ VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 DATE := $(shell date -u '+%Y-%m-%dT%H:%M:%SZ')
 LDFLAGS := -ldflags "-s -w \
-	-X github.com/piekstra/slack-chat-api/internal/version.Version=$(VERSION) \
-	-X github.com/piekstra/slack-chat-api/internal/version.Commit=$(COMMIT) \
-	-X github.com/piekstra/slack-chat-api/internal/version.Date=$(DATE)"
+	-X github.com/open-cli-collective/slack-chat-api/internal/version.Version=$(VERSION) \
+	-X github.com/open-cli-collective/slack-chat-api/internal/version.Commit=$(COMMIT) \
+	-X github.com/open-cli-collective/slack-chat-api/internal/version.Date=$(DATE)"
 
 DIST_DIR = dist
 
@@ -31,7 +31,7 @@ lint:
 
 fmt:
 	go fmt ./...
-	goimports -local github.com/piekstra/slack-chat-api -w .
+	goimports -local github.com/open-cli-collective/slack-chat-api -w .
 
 deps:
 	go mod download

--- a/cmd/slack-chat-api/main.go
+++ b/cmd/slack-chat-api/main.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"github.com/piekstra/slack-chat-api/internal/cmd/root"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/root"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/piekstra/slack-chat-api
+module github.com/open-cli-collective/slack-chat-api
 
 go 1.21
 

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -9,7 +9,7 @@ import (
 	"net/url"
 	"time"
 
-	"github.com/piekstra/slack-chat-api/internal/keychain"
+	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
 )
 
 const defaultBaseURL = "https://slack.com/api"

--- a/internal/cmd/channels/archive.go
+++ b/internal/cmd/channels/archive.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
-	"github.com/piekstra/slack-chat-api/internal/validate"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
 )
 
 type archiveOptions struct {

--- a/internal/cmd/channels/channels_test.go
+++ b/internal/cmd/channels/channels_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 func TestRunList_Success(t *testing.T) {

--- a/internal/cmd/channels/create.go
+++ b/internal/cmd/channels/create.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type createOptions struct {

--- a/internal/cmd/channels/get.go
+++ b/internal/cmd/channels/get.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type getOptions struct{}

--- a/internal/cmd/channels/invite.go
+++ b/internal/cmd/channels/invite.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type inviteOptions struct{}

--- a/internal/cmd/channels/list.go
+++ b/internal/cmd/channels/list.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type listOptions struct {

--- a/internal/cmd/channels/set_purpose.go
+++ b/internal/cmd/channels/set_purpose.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type setPurposeOptions struct{}

--- a/internal/cmd/channels/set_topic.go
+++ b/internal/cmd/channels/set_topic.go
@@ -3,8 +3,8 @@ package channels
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type setTopicOptions struct{}

--- a/internal/cmd/channels/unarchive.go
+++ b/internal/cmd/channels/unarchive.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type unarchiveOptions struct{}

--- a/internal/cmd/config/config_test.go
+++ b/internal/cmd/config/config_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-chat-api/internal/keychain"
+	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
 )
 
 func TestRunSetToken_Success(t *testing.T) {

--- a/internal/cmd/config/delete_token.go
+++ b/internal/cmd/config/delete_token.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/keychain"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type deleteTokenOptions struct {

--- a/internal/cmd/config/set_token.go
+++ b/internal/cmd/config/set_token.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/keychain"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type setTokenOptions struct{}

--- a/internal/cmd/config/show.go
+++ b/internal/cmd/config/show.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/keychain"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type showOptions struct{}

--- a/internal/cmd/config/test.go
+++ b/internal/cmd/config/test.go
@@ -3,8 +3,8 @@ package config
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type testOptions struct{}

--- a/internal/cmd/config/test_test.go
+++ b/internal/cmd/config/test_test.go
@@ -9,8 +9,8 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/keychain"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/keychain"
 )
 
 func TestRunTest_Success(t *testing.T) {

--- a/internal/cmd/messages/delete.go
+++ b/internal/cmd/messages/delete.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
-	"github.com/piekstra/slack-chat-api/internal/validate"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
 )
 
 type deleteOptions struct {

--- a/internal/cmd/messages/history.go
+++ b/internal/cmd/messages/history.go
@@ -3,8 +3,8 @@ package messages
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type historyOptions struct {

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 func TestFormatTimestamp(t *testing.T) {

--- a/internal/cmd/messages/react.go
+++ b/internal/cmd/messages/react.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
-	"github.com/piekstra/slack-chat-api/internal/validate"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
 )
 
 type reactOptions struct{}

--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -9,9 +9,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
-	"github.com/piekstra/slack-chat-api/internal/validate"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
 )
 
 type sendOptions struct {

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -3,8 +3,8 @@ package messages
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type threadOptions struct {

--- a/internal/cmd/messages/unreact.go
+++ b/internal/cmd/messages/unreact.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
-	"github.com/piekstra/slack-chat-api/internal/validate"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
 )
 
 type unreactOptions struct{}

--- a/internal/cmd/messages/update.go
+++ b/internal/cmd/messages/update.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type updateOptions struct {

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -6,14 +6,14 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/cmd/channels"
-	"github.com/piekstra/slack-chat-api/internal/cmd/config"
-	"github.com/piekstra/slack-chat-api/internal/cmd/messages"
-	"github.com/piekstra/slack-chat-api/internal/cmd/search"
-	"github.com/piekstra/slack-chat-api/internal/cmd/users"
-	"github.com/piekstra/slack-chat-api/internal/cmd/workspace"
-	"github.com/piekstra/slack-chat-api/internal/output"
-	"github.com/piekstra/slack-chat-api/internal/version"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/channels"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/config"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/messages"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/search"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/users"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/workspace"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/version"
 )
 
 var outputFormat string

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -3,8 +3,8 @@ package search
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type allOptions struct {

--- a/internal/cmd/search/files.go
+++ b/internal/cmd/search/files.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type filesOptions struct {

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type messagesOptions struct {

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 // Helper to create a test client with a mock server

--- a/internal/cmd/users/get.go
+++ b/internal/cmd/users/get.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type getOptions struct{}

--- a/internal/cmd/users/list.go
+++ b/internal/cmd/users/list.go
@@ -3,8 +3,8 @@ package users
 import (
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type listOptions struct {

--- a/internal/cmd/users/search.go
+++ b/internal/cmd/users/search.go
@@ -6,8 +6,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 // ValidFields contains the allowed field filter values

--- a/internal/cmd/users/search_test.go
+++ b/internal/cmd/users/search_test.go
@@ -6,7 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 // Helper to create a test client with a mock server

--- a/internal/cmd/users/users_test.go
+++ b/internal/cmd/users/users_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 func TestRunList_Success(t *testing.T) {

--- a/internal/cmd/workspace/info.go
+++ b/internal/cmd/workspace/info.go
@@ -5,8 +5,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
-	"github.com/piekstra/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 type infoOptions struct{}

--- a/internal/cmd/workspace/workspace_test.go
+++ b/internal/cmd/workspace/workspace_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/piekstra/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 func TestRunInfo_Success(t *testing.T) {


### PR DESCRIPTION
## Summary

Migrate Go module path and all imports from `github.com/piekstra/slack-chat-api` to `github.com/open-cli-collective/slack-chat-api` to reflect the repository's new organization home.

## Changes

- **go.mod**: Updated module declaration
- **Build config**: Updated Makefile, .goreleaser.yaml
- **.golangci.yml**: Updated local-prefixes (also fixed typo: `slack-cli` → `slack-chat-api`)
- **Go source files**: Updated all import statements (37 files)
- **Documentation**: Updated CHANGELOG.md GitHub URLs

## Test Plan

- [x] `go mod tidy` succeeds
- [x] `make build` succeeds
- [x] `make test` passes (all tests)
- [x] `make lint` passes (0 issues)
- [x] No piekstra references remaining in codebase

Closes #75