### PR TITLE
feat: add Linux distribution support (Snap, APT, RPM)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,3 +296,41 @@ jobs:
 
           Write-Host "`nSubmitting new package to Winget..."
           ./wingetcreate.exe submit --token $env:WINGET_GITHUB_TOKEN $manifestDir
+
+  snap:
+    if: false  # Temporarily disabled - waiting for personal-files interface approval
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+
+      - name: Publish to Snapcraft Store
+        uses: snapcore/action-publish@v1
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable
+
+  linux-packages:
+    needs: goreleaser
+    runs-on: ubuntu-latest
+    steps:
+      - name: Trigger linux-packages repo update
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.LINUX_PACKAGES_DISPATCH_TOKEN }}
+          repository: open-cli-collective/linux-packages
+          event-type: package-release
+          client-payload: |-
+            {
+              "package": "slck",
+              "version": "${{ github.ref_name }}",
+              "repo": "open-cli-collective/slack-chat-api"
+            }

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,15 +27,34 @@ builds:
       - -X github.com/open-cli-collective/slack-chat-api/internal/version.Date={{.Date}}
 
 archives:
-  - format: tar.gz
+  - formats:
+      - tar.gz
     format_overrides:
       - goos: windows
-        format: zip
+        formats:
+          - zip
     # Use binary name with v prefix for archive filenames
     name_template: "slck_v{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - LICENSE
       - README.md
+
+# Linux packages (.deb and .rpm)
+nfpms:
+  - id: slck
+    package_name: slck
+    vendor: Open CLI Collective
+    homepage: https://github.com/open-cli-collective/slack-chat-api
+    maintainer: Open CLI Collective <https://github.com/open-cli-collective>
+    description: Command-line interface for Slack
+    license: MIT
+    formats:
+      - deb
+      - rpm
+    bindir: /usr/bin
+    contents:
+      - src: LICENSE
+        dst: /usr/share/licenses/slck/LICENSE
 
 checksum:
   name_template: "checksums.txt"

--- a/README.md
+++ b/README.md
@@ -24,24 +24,84 @@ This project is **not** affiliated with Slack or Salesforce. If you're looking t
 
 ## Installation
 
-### Homebrew (macOS/Linux)
+### macOS
+
+**Homebrew (recommended)**
 
 ```bash
-brew tap open-cli-collective/tap
-brew install --cask slack-chat-cli
+brew install open-cli-collective/tap/slack-chat-cli
 ```
 
-### Chocolatey (Windows)
+> Note: This installs from our third-party tap.
+
+---
+
+### Windows
+
+**Chocolatey**
 
 ```powershell
 choco install slack-chat-cli
 ```
 
-### Winget (Windows)
+**Winget**
 
 ```powershell
 winget install OpenCLICollective.slack-chat-cli
 ```
+
+---
+
+### Linux
+
+**Snap**
+
+```bash
+sudo snap install ocli-slack
+```
+
+> Note: After installation, the command is available as `slck`.
+
+**APT (Debian/Ubuntu)**
+
+```bash
+# Add the GPG key
+curl -fsSL https://open-cli-collective.github.io/linux-packages/keys/gpg.asc | sudo gpg --dearmor -o /usr/share/keyrings/open-cli-collective.gpg
+
+# Add the repository
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/open-cli-collective.gpg] https://open-cli-collective.github.io/linux-packages/apt stable main" | sudo tee /etc/apt/sources.list.d/open-cli-collective.list
+
+# Install
+sudo apt update
+sudo apt install slck
+```
+
+> Note: This is our third-party APT repository, not official Debian/Ubuntu repos.
+
+**DNF/YUM (Fedora/RHEL/CentOS)**
+
+```bash
+# Add the repository
+sudo tee /etc/yum.repos.d/open-cli-collective.repo << 'EOF'
+[open-cli-collective]
+name=Open CLI Collective
+baseurl=https://open-cli-collective.github.io/linux-packages/rpm
+enabled=1
+gpgcheck=1
+gpgkey=https://open-cli-collective.github.io/linux-packages/keys/gpg.asc
+EOF
+
+# Install
+sudo dnf install slck
+```
+
+> Note: This is our third-party RPM repository, not official Fedora/RHEL repos.
+
+**Binary download**
+
+Download `.deb`, `.rpm`, or `.tar.gz` from the [Releases page](https://github.com/open-cli-collective/slack-chat-api/releases).
+
+---
 
 ### From Source
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,62 @@
+name: ocli-slack
+base: core22
+version: git
+summary: Command-line interface for Slack
+description: |
+  slck is a CLI for interacting with the Slack Web API.
+
+  Features:
+  - Send messages to channels
+  - List and manage channels
+  - Search users and conversations
+  - Message reactions and threads
+  - JSON output for scripting
+
+  Run 'slck config set-token' to configure your Slack token.
+
+grade: stable
+confinement: strict
+
+architectures:
+  - build-on: amd64
+  - build-on: arm64
+
+plugs:
+  dot-config-slack-chat-api:
+    interface: personal-files
+    read:
+      - $HOME/.config/slack-chat-api
+    write:
+      - $HOME/.config/slack-chat-api
+
+apps:
+  ocli-slack:
+    command: bin/slck
+    plugs:
+      - home
+      - network
+      - dot-config-slack-chat-api
+    aliases:
+      - slck
+
+parts:
+  slck:
+    plugin: go
+    source: .
+    build-snaps:
+      - go/1.24/stable
+    build-environment:
+      - CGO_ENABLED: "0"
+    override-build: |
+      # Get version from git
+      VERSION=$(git describe --tags --always --dirty 2>/dev/null || echo "dev")
+      COMMIT=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
+      DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+      # Build with ldflags
+      go build -o $SNAPCRAFT_PART_INSTALL/bin/slck \
+        -ldflags "-s -w \
+          -X github.com/open-cli-collective/slack-chat-api/internal/version.Version=${VERSION} \
+          -X github.com/open-cli-collective/slack-chat-api/internal/version.Commit=${COMMIT} \
+          -X github.com/open-cli-collective/slack-chat-api/internal/version.Date=${DATE}" \
+        ./cmd/slck


### PR DESCRIPTION
## Summary

Add Linux distribution support for slack-chat-api, enabling users to install via:
- **Snap Store** (as `ocli-slack`, aliased to `slck`)
- **APT** (Debian/Ubuntu) via open-cli-collective linux-packages repo
- **DNF/YUM** (Fedora/RHEL/CentOS) via open-cli-collective linux-packages repo
- **Direct download** of `.deb` and `.rpm` packages from GitHub Releases

## Changes

- **`.goreleaser.yaml`**: 
  - Added `nfpms` section to generate `.deb` and `.rpm` packages
  - Fixed deprecated archive format syntax (`format` -> `formats`)
- **`snap/snapcraft.yaml`**: New file for Snap package definition with:
  - `personal-files` interface for `~/.config/slack-chat-api` access
  - Go 1.24 build with version ldflags
- **`.github/workflows/release.yml`**: Added two new jobs:
  - `snap`: Build and publish to Snap Store (disabled with `if: false` pending personal-files interface approval)
  - `linux-packages`: Trigger APT/RPM repo update via repository dispatch
- **`README.md`**: Comprehensive Linux installation instructions

## Required Secrets (to be added before release)

| Secret | Purpose |
|--------|---------|
| `SNAPCRAFT_STORE_CREDENTIALS` | Publish to Snap Store |
| `LINUX_PACKAGES_DISPATCH_TOKEN` | Trigger linux-packages workflow |

## Notes

- Snap job is disabled (`if: false`) pending personal-files interface approval from Canonical
- Uses `ocli-slack` as snap name with `slck` alias
- Also fixed goreleaser deprecation warnings for archive format syntax

## Test Plan

- [x] `goreleaser check` passes
- [x] `make build` succeeds
- [x] `make test` passes
- [x] `make lint` passes
- [ ] After merge: Verify `.deb`/`.rpm` packages appear in GitHub Release
- [ ] After secrets configured: Verify linux-packages dispatch triggers

Closes #81