### PR TITLE
fix: Correct GitHub releases URL in Chocolatey install script

### DIFF
--- a/packaging/chocolatey/tools/chocolateyInstall.ps1
+++ b/packaging/chocolatey/tools/chocolateyInstall.ps1
@@ -18,7 +18,7 @@ if ($env:PROCESSOR_ARCHITECTURE -eq 'ARM64') {
     throw "32-bit Windows is not supported. slck requires 64-bit Windows."
 }
 
-$baseUrl = "https://github.com/open-cli-collective/slck/releases/download/v${version}"
+$baseUrl = "https://github.com/open-cli-collective/slack-chat-api/releases/download/v${version}"
 $zipFile = "slck_v${version}_windows_${arch}.zip"
 $url = "${baseUrl}/${zipFile}"
 


### PR DESCRIPTION
## Summary
- Fix incorrect GitHub releases URL in Chocolatey install script
- Was pointing to non-existent `slck` repo instead of `slack-chat-api`
- This caused 404 errors during installation, which Chocolatey reported as a timeout/hang

Fixes #87