### PR TITLE
feat: Accept Slack URL format for thread timestamps

### DIFF
--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -82,11 +82,12 @@ func runSend(channel, text string, opts *sendOptions, c *client.Client) error {
 		return err
 	}
 
-	// Validate thread timestamp if provided
+	// Validate and normalize thread timestamp if provided
 	if opts.threadTS != "" {
 		if err := validate.Timestamp(opts.threadTS); err != nil {
 			return err
 		}
+		opts.threadTS = validate.NormalizeTimestamp(opts.threadTS)
 	}
 
 	// Validate mutually exclusive blocks options

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
 	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
 )
 
 type threadOptions struct {
@@ -29,6 +30,9 @@ func newThreadCmd() *cobra.Command {
 }
 
 func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) error {
+	// Normalize thread timestamp (accepts API format, p-prefixed, or full URL)
+	threadTS = validate.NormalizeTimestamp(threadTS)
+
 	if c == nil {
 		var err error
 		c, err = client.New()


### PR DESCRIPTION
## Summary

Accept multiple timestamp formats for the `--thread` flag and thread command argument:

- Standard API format: `1234567890.123456`
- P-prefixed format: `p1234567890123456`  
- Full Slack URL: `https://workspace.slack.com/archives/C123/p1234567890123456`

This allows users to copy-paste thread URLs directly from Slack without manual conversion.

## Changes

- Added `NormalizeTimestamp()` function in `internal/validate/validate.go`
- Updated `Timestamp()` validator to normalize before validation
- Updated `messages send --thread` to normalize timestamp
- Updated `messages thread` command to normalize timestamp argument
- Added comprehensive tests for all formats

## Usage

```bash
# All of these now work:
slck messages send C123 "reply" --thread 1234567890.123456
slck messages send C123 "reply" --thread p1234567890123456
slck messages send C123 "reply" --thread "https://myworkspace.slack.com/archives/C123/p1234567890123456"

slck messages thread C123 p1234567890123456
slck messages thread C123 "https://myworkspace.slack.com/archives/C123/p1234567890123456"
```

Closes #71