### PR TITLE
feat(search): add --include-bots flag to search commands

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -720,7 +720,7 @@ func (c *Client) InviteToChannel(channel string, users []string) error {
 // --- Search Methods (require user token) ---
 
 // SearchMessages searches for messages matching a query
-func (c *Client) SearchMessages(query string, count, page int, sort, sortDir string, highlight bool) (*SearchResult, error) {
+func (c *Client) SearchMessages(query string, count, page int, sort, sortDir string, highlight, includeBots bool) (*SearchResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
 	params.Set("count", fmt.Sprintf("%d", count))
@@ -729,6 +729,9 @@ func (c *Client) SearchMessages(query string, count, page int, sort, sortDir str
 	params.Set("sort_dir", sortDir)
 	if highlight {
 		params.Set("highlight", "true")
+	}
+	if includeBots {
+		params.Set("search_exclude_bots", "false")
 	}
 
 	body, err := c.get("search.messages", params)
@@ -745,7 +748,7 @@ func (c *Client) SearchMessages(query string, count, page int, sort, sortDir str
 }
 
 // SearchFiles searches for files matching a query
-func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string, highlight bool) (*SearchResult, error) {
+func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string, highlight, includeBots bool) (*SearchResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
 	params.Set("count", fmt.Sprintf("%d", count))
@@ -754,6 +757,9 @@ func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string
 	params.Set("sort_dir", sortDir)
 	if highlight {
 		params.Set("highlight", "true")
+	}
+	if includeBots {
+		params.Set("search_exclude_bots", "false")
 	}
 
 	body, err := c.get("search.files", params)
@@ -770,7 +776,7 @@ func (c *Client) SearchFiles(query string, count, page int, sort, sortDir string
 }
 
 // SearchAll searches for both messages and files matching a query
-func (c *Client) SearchAll(query string, count, page int, sort, sortDir string, highlight bool) (*SearchResult, error) {
+func (c *Client) SearchAll(query string, count, page int, sort, sortDir string, highlight, includeBots bool) (*SearchResult, error) {
 	params := url.Values{}
 	params.Set("query", query)
 	params.Set("count", fmt.Sprintf("%d", count))
@@ -779,6 +785,9 @@ func (c *Client) SearchAll(query string, count, page int, sort, sortDir string, 
 	params.Set("sort_dir", sortDir)
 	if highlight {
 		params.Set("highlight", "true")
+	}
+	if includeBots {
+		params.Set("search_exclude_bots", "false")
 	}
 
 	body, err := c.get("search.all", params)

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -973,7 +973,7 @@ func TestClient_SearchMessages_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	result, err := client.SearchMessages("test query", 20, 1, "score", "desc", false)
+	result, err := client.SearchMessages("test query", 20, 1, "score", "desc", false, false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1015,7 +1015,7 @@ func TestClient_SearchMessages_WithHighlight(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	_, err := client.SearchMessages("test", 20, 1, "score", "desc", true)
+	_, err := client.SearchMessages("test", 20, 1, "score", "desc", true, false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1034,7 +1034,7 @@ func TestClient_SearchMessages_APIError(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	_, err := client.SearchMessages("test", 20, 1, "score", "desc", false)
+	_, err := client.SearchMessages("test", 20, 1, "score", "desc", false, false)
 
 	if err == nil {
 		t.Error("expected error for API failure")
@@ -1079,7 +1079,7 @@ func TestClient_SearchFiles_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	result, err := client.SearchFiles("document", 20, 1, "score", "desc", false)
+	result, err := client.SearchFiles("document", 20, 1, "score", "desc", false, false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -1153,7 +1153,7 @@ func TestClient_SearchAll_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	result, err := client.SearchAll("report", 20, 1, "timestamp", "asc", false)
+	result, err := client.SearchAll("report", 20, 1, "timestamp", "asc", false, false)
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -20,6 +20,7 @@ type allOptions struct {
 	before      string
 	hasLink     bool
 	hasReaction bool
+	includeBots bool
 }
 
 func newAllCmd() *cobra.Command {
@@ -66,6 +67,7 @@ Examples:
 	cmd.Flags().StringVar(&opts.before, "before", "", "Content before date (YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&opts.hasLink, "has-link", false, "Content containing links")
 	cmd.Flags().BoolVar(&opts.hasReaction, "has-reaction", false, "Content with reactions")
+	cmd.Flags().BoolVar(&opts.includeBots, "include-bots", false, "Include bot messages in results")
 
 	return cmd
 }
@@ -99,7 +101,7 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 	}
 	finalQuery := BuildQuery(query, queryOpts)
 
-	result, err := c.SearchAll(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight)
+	result, err := c.SearchAll(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight, opts.includeBots)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/search/files.go
+++ b/internal/cmd/search/files.go
@@ -10,18 +10,19 @@ import (
 )
 
 type filesOptions struct {
-	count     int
-	page      int
-	sort      string
-	sortDir   string
-	highlight bool
-	scope     string
-	inChannel string
-	fromUser  string
-	after     string
-	before    string
-	fileType  string
-	hasPin    bool
+	count       int
+	page        int
+	sort        string
+	sortDir     string
+	highlight   bool
+	scope       string
+	inChannel   string
+	fromUser    string
+	after       string
+	before      string
+	fileType    string
+	hasPin      bool
+	includeBots bool
 }
 
 func newFilesCmd() *cobra.Command {
@@ -67,6 +68,7 @@ Examples:
 	cmd.Flags().StringVar(&opts.before, "before", "", "Files before date (YYYY-MM-DD)")
 	cmd.Flags().StringVar(&opts.fileType, "type", "", "Filter by file type (pdf, doc, image, etc.)")
 	cmd.Flags().BoolVar(&opts.hasPin, "has-pin", false, "Files that are pinned")
+	cmd.Flags().BoolVar(&opts.includeBots, "include-bots", false, "Include bot messages in results")
 
 	return cmd
 }
@@ -100,7 +102,7 @@ func runSearchFiles(query string, opts *filesOptions, c *client.Client) error {
 	}
 	finalQuery := BuildQuery(query, queryOpts)
 
-	result, err := c.SearchFiles(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight)
+	result, err := c.SearchFiles(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight, opts.includeBots)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -25,6 +25,7 @@ type messagesOptions struct {
 	before      string
 	hasLink     bool
 	hasReaction bool
+	includeBots bool
 }
 
 func newMessagesCmd() *cobra.Command {
@@ -52,7 +53,8 @@ Examples:
   slck search messages "project update" --from "@alice"
   slck search messages "deployment" --after 2025-01-01
   slck search messages "test" --scope public
-  slck search messages "meeting" --has-link --has-reaction`,
+  slck search messages "meeting" --has-link --has-reaction
+  slck search messages "alert" --include-bots`,
 		Args: cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runSearchMessages(args[0], opts, nil)
@@ -73,6 +75,7 @@ Examples:
 	cmd.Flags().StringVar(&opts.before, "before", "", "Messages before date (YYYY-MM-DD)")
 	cmd.Flags().BoolVar(&opts.hasLink, "has-link", false, "Messages containing links")
 	cmd.Flags().BoolVar(&opts.hasReaction, "has-reaction", false, "Messages with reactions")
+	cmd.Flags().BoolVar(&opts.includeBots, "include-bots", false, "Include bot messages in results")
 
 	return cmd
 }
@@ -106,7 +109,7 @@ func runSearchMessages(query string, opts *messagesOptions, c *client.Client) er
 	}
 	finalQuery := BuildQuery(query, queryOpts)
 
-	result, err := c.SearchMessages(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight)
+	result, err := c.SearchMessages(finalQuery, opts.count, opts.page, opts.sort, opts.sortDir, opts.highlight, opts.includeBots)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -706,6 +706,70 @@ func TestSearchMessages_WithHighlight(t *testing.T) {
 	}
 }
 
+func TestSearchMessages_WithIncludeBots(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":   0,
+			"paging":  map[string]interface{}{"count": 20, "total": 0, "page": 1, "pages": 0},
+			"matches": []map[string]interface{}{},
+		},
+	}
+
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("search_exclude_bots") != "false" {
+			t.Errorf("expected search_exclude_bots=false, got %s", r.URL.Query().Get("search_exclude_bots"))
+		}
+		json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	opts := &messagesOptions{
+		count:       20,
+		page:        1,
+		sort:        "score",
+		sortDir:     "desc",
+		includeBots: true,
+	}
+
+	err := runSearchMessages("bot-alert", opts, c)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestSearchMessages_WithoutIncludeBots(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":   0,
+			"paging":  map[string]interface{}{"count": 20, "total": 0, "page": 1, "pages": 0},
+			"matches": []map[string]interface{}{},
+		},
+	}
+
+	c, server := newTestClient(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("search_exclude_bots") != "" {
+			t.Errorf("expected search_exclude_bots to be absent, got %s", r.URL.Query().Get("search_exclude_bots"))
+		}
+		json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	opts := &messagesOptions{
+		count:       20,
+		page:        1,
+		sort:        "score",
+		sortDir:     "desc",
+		includeBots: false,
+	}
+
+	err := runSearchMessages("test", opts, c)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
 func TestSearchMessages_WithSortOptions(t *testing.T) {
 	response := map[string]interface{}{
 		"ok": true,


### PR DESCRIPTION
## Summary

- Adds `--include-bots` flag to `search messages`, `search files`, and `search all` commands
- When set, passes `search_exclude_bots=false` to the Slack API to include bot messages in results
- Includes unit tests for the new flag behavior

## Test plan

- [x] Unit tests verify `search_exclude_bots=false` is sent when `--include-bots` is set
- [x] Unit tests verify the parameter is absent when `--include-bots` is not set
- [x] All existing tests pass
- [x] Lint passes

Closes #92