### PR TITLE
feat(messages): resolve user IDs to display names in output

### DIFF
--- a/internal/client/resolver.go
+++ b/internal/client/resolver.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"regexp"
+	"sync"
+)
+
+// UserResolver resolves Slack user IDs to display names with caching.
+type UserResolver struct {
+	client *Client
+	cache  map[string]string
+	mu     sync.Mutex
+}
+
+var mentionRegex = regexp.MustCompile(`<@(U[A-Z0-9]+)>`)
+
+// NewUserResolver creates a resolver backed by the given client.
+func NewUserResolver(c *Client) *UserResolver {
+	return &UserResolver{
+		client: c,
+		cache:  make(map[string]string),
+	}
+}
+
+// Resolve returns a display name for the given user ID.
+// It returns the ID unchanged if the lookup fails.
+func (r *UserResolver) Resolve(userID string) string {
+	if userID == "" {
+		return userID
+	}
+
+	r.mu.Lock()
+	if name, ok := r.cache[userID]; ok {
+		r.mu.Unlock()
+		return name
+	}
+	r.mu.Unlock()
+
+	user, err := r.client.GetUserInfo(userID)
+	if err != nil {
+		return userID
+	}
+
+	name := user.Profile.DisplayName
+	if name == "" {
+		name = user.RealName
+	}
+	if name == "" {
+		name = user.Name
+	}
+	if name == "" {
+		name = userID
+	}
+
+	r.mu.Lock()
+	r.cache[userID] = name
+	r.mu.Unlock()
+
+	return name
+}
+
+// ResolveMentions replaces <@UXXXXX> mentions in text with display names.
+func (r *UserResolver) ResolveMentions(text string) string {
+	return mentionRegex.ReplaceAllStringFunc(text, func(match string) string {
+		sub := mentionRegex.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		return "@" + r.Resolve(sub[1])
+	})
+}

--- a/internal/client/resolver_test.go
+++ b/internal/client/resolver_test.go
@@ -1,0 +1,124 @@
+package client
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func newMockUserServer(t *testing.T, users map[string]string) *httptest.Server {
+	t.Helper()
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/users.info", r.URL.Path)
+		uid := r.URL.Query().Get("user")
+		name, ok := users[uid]
+		if !ok {
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":    false,
+				"error": "user_not_found",
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"user": map[string]interface{}{
+				"id":        uid,
+				"name":      name,
+				"real_name": name,
+				"profile": map[string]interface{}{
+					"display_name": name,
+				},
+			},
+		})
+	}))
+}
+
+func TestUserResolver_Resolve(t *testing.T) {
+	server := newMockUserServer(t, map[string]string{
+		"U001": "alice",
+		"U002": "bob",
+	})
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-token", nil)
+	r := NewUserResolver(c)
+
+	assert.Equal(t, "alice", r.Resolve("U001"))
+	assert.Equal(t, "bob", r.Resolve("U002"))
+}
+
+func TestUserResolver_Cache(t *testing.T) {
+	var callCount atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount.Add(1)
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"user": map[string]interface{}{
+				"id":   "U001",
+				"name": "alice",
+				"profile": map[string]interface{}{
+					"display_name": "alice",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-token", nil)
+	r := NewUserResolver(c)
+
+	r.Resolve("U001")
+	r.Resolve("U001")
+	r.Resolve("U001")
+
+	assert.Equal(t, int32(1), callCount.Load(), "should only call API once due to caching")
+}
+
+func TestUserResolver_FallbackOnError(t *testing.T) {
+	server := newMockUserServer(t, map[string]string{})
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-token", nil)
+	r := NewUserResolver(c)
+
+	assert.Equal(t, "U999", r.Resolve("U999"))
+}
+
+func TestUserResolver_EmptyID(t *testing.T) {
+	r := NewUserResolver(nil)
+	assert.Equal(t, "", r.Resolve(""))
+}
+
+func TestUserResolver_ResolveMentions(t *testing.T) {
+	server := newMockUserServer(t, map[string]string{
+		"U001": "alice",
+		"U002": "bob",
+	})
+	defer server.Close()
+
+	c := NewWithConfig(server.URL, "test-token", nil)
+	r := NewUserResolver(c)
+
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"no mentions", "hello world", "hello world"},
+		{"single mention", "hey <@U001>!", "hey @alice!"},
+		{"multiple mentions", "<@U001> and <@U002> are here", "@alice and @bob are here"},
+		{"unknown user", "hey <@U999>", "hey @U999"},
+		{"empty string", "", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, r.ResolveMentions(tt.input))
+		})
+	}
+}

--- a/internal/cmd/messages/history.go
+++ b/internal/cmd/messages/history.go
@@ -55,10 +55,12 @@ func runHistory(channel string, opts *historyOptions, c *client.Client) error {
 		return nil
 	}
 
+	resolver := client.NewUserResolver(c)
 	for _, m := range messages {
 		ts := formatTimestamp(m.TS)
-		text := truncate(m.Text, 80)
-		output.Printf("[%s] %s: %s\n", ts, m.User, text)
+		text := truncate(resolver.ResolveMentions(m.Text), 80)
+		name := resolver.Resolve(m.User)
+		output.Printf("[%s] %s: %s\n", ts, name, text)
 	}
 
 	return nil

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -55,10 +55,12 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 		return nil
 	}
 
+	resolver := client.NewUserResolver(c)
 	for _, m := range messages {
 		ts := formatTimestamp(m.TS)
-		text := truncate(m.Text, 80)
-		output.Printf("[%s] %s: %s\n", ts, m.User, text)
+		text := truncate(resolver.ResolveMentions(m.Text), 80)
+		name := resolver.Resolve(m.User)
+		output.Printf("[%s] %s: %s\n", ts, name, text)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary

- Adds `UserResolver` in `internal/client/resolver.go` with in-memory caching to translate Slack user IDs to display names
- Resolves user IDs shown as message authors in `messages history` and `messages thread` output
- Resolves inline `<@UXXXXX>` mentions within message text to `@displayname`
- Falls back to user ID if lookup fails; uses display name → real name → username priority

## Test plan

- [x] All existing tests updated and passing
- [x] New resolver tests cover: resolution, caching (single API call), error fallback, empty ID, and mention replacement
- [x] Linter passes with 0 issues
- [ ] Manual test with real Slack workspace: `slck messages history <channel>` shows names instead of IDs
- [ ] Manual test: `slck messages thread <channel> <ts>` shows names instead of IDs

Closes #97