### PR TITLE
docs: fix app manifest to work with Slack's YAML parser

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,28 +143,72 @@ make build
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) → **Create New App** → **From an app manifest**
 2. Select your workspace
-3. Paste this manifest (YAML tab):
+3. Paste this manifest (JSON tab recommended):
+   ```json
+   {
+     "display_information": {
+       "name": "Slack Chat API"
+     },
+     "features": {
+       "bot_user": {
+         "display_name": "Slack Chat API",
+         "always_online": false
+       }
+     },
+     "oauth_config": {
+       "scopes": {
+         "bot": [
+           "channels:history",
+           "channels:manage",
+           "channels:read",
+           "chat:write",
+           "groups:history",
+           "groups:read",
+           "reactions:write",
+           "team:read",
+           "users:read"
+         ],
+         "user": [
+           "search:read"
+         ]
+       }
+     },
+     "settings": {
+       "org_deploy_enabled": false,
+       "socket_mode_enabled": false
+     }
+   }
+   ```
+
+   <details>
+   <summary>YAML alternative (if you prefer)</summary>
+
    ```yaml
    display_information:
      name: Slack Chat API
+   features:
+     bot_user:
+       display_name: Slack Chat API
+       always_online: false
    oauth_config:
      scopes:
        bot:
-         - channels:history
-         - channels:manage
-         - channels:read
-         - chat:write
-         - groups:history
-         - groups:read
-         - reactions:write
-         - team:read
-         - users:read
+         - "channels:history"
+         - "channels:manage"
+         - "channels:read"
+         - "chat:write"
+         - "groups:history"
+         - "groups:read"
+         - "reactions:write"
+         - "team:read"
+         - "users:read"
        user:
-         - search:read
+         - "search:read"
    settings:
      org_deploy_enabled: false
      socket_mode_enabled: false
    ```
+   </details>
 4. Click **Create** → **Install to Workspace** → **Allow**
 5. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
 6. Run:


### PR DESCRIPTION
## Summary
- Add missing `features.bot_user` block required when requesting bot scopes
- Switch to JSON as the primary manifest format (more reliable with Slack's parser)
- Keep YAML as a collapsible alternative with properly quoted scope values

## Problem
The previous YAML manifest was being rejected by Slack with parser errors. Two issues:
1. Missing `features.bot_user` section - required when defining bot scopes
2. Slack's YAML parser can be strict with values containing colons (like `channels:history`)

## Solution
- Use JSON as the primary format since it's more reliably parsed
- Include YAML as a collapsible `<details>` section for those who prefer it
- Quote all scope values in YAML to avoid parser issues