### PR TITLE
fix: inject snap package version from git tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -308,6 +308,13 @@ jobs:
           ref: ${{ env.TAG }}
           fetch-depth: 0
 
+      - name: Set snap version from tag
+        run: |
+          VERSION="${TAG#v}"
+          sed -i "s/^version: git$/version: '${VERSION}'/" snap/snapcraft.yaml
+          echo "Snap version: ${VERSION}"
+          grep '^version:' snap/snapcraft.yaml
+
       - name: Build snap
         uses: snapcore/action-build@v1
         id: build


### PR DESCRIPTION
## Summary
- Snap packages show versions like `0+git.9337614` instead of proper semver in the Snapcraft Store
- Root cause: `version: git` in snapcraft.yaml relies on `git describe --tags` which fails inside the LXD build container
- Fix: inject version from git tag into snapcraft.yaml before `snapcore/action-build` runs

Fixes #111

## Test plan
- [ ] Verify CI passes
- [ ] Next release will publish snap with proper semver version