### PR TITLE
feat(messages): include reactions in JSON output

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -223,14 +223,22 @@ type User struct {
 	} `json:"profile"`
 }
 
+// Reaction represents an emoji reaction on a Slack message
+type Reaction struct {
+	Name  string   `json:"name"`
+	Count int      `json:"count"`
+	Users []string `json:"users"`
+}
+
 // Message represents a Slack message
 type Message struct {
-	Type       string `json:"type"`
-	User       string `json:"user"`
-	Text       string `json:"text"`
-	TS         string `json:"ts"`
-	ThreadTS   string `json:"thread_ts,omitempty"`
-	ReplyCount int    `json:"reply_count,omitempty"`
+	Type       string     `json:"type"`
+	User       string     `json:"user"`
+	Text       string     `json:"text"`
+	TS         string     `json:"ts"`
+	ThreadTS   string     `json:"thread_ts,omitempty"`
+	ReplyCount int        `json:"reply_count,omitempty"`
+	Reactions  []Reaction `json:"reactions,omitempty"`
 }
 
 // Team represents workspace info


### PR DESCRIPTION
Closes #113

## Why

The Slack API returns reaction data on messages from `conversations.replies` and `conversations.history`, but the CLI's `Message` struct had no `Reactions` field — so this data was silently discarded during JSON unmarshalling. Integrations that consume `-o json` output couldn't see which reactions were on messages, losing important thread context (e.g., acknowledgements, approvals).

## What changed

- Added `Reaction` type (`name`, `count`, `users`) to the client package
- Added `Reactions []Reaction` field (with `omitempty`) to `Message` struct
- The Slack API already returns this data — no API call changes needed, just struct alignment

## Test plan

- [x] New client tests verify reactions are deserialized from mock API responses (both `GetThreadReplies` and `GetChannelHistory`)
- [x] New command tests verify reactions appear in JSON output from `runThread` and `runHistory`
- [x] Existing tests continue to pass (messages without reactions are unaffected due to `omitempty`)
- [x] Full test suite green