### PR TITLE
feat(messages): add --channel flag to send command

### DIFF
--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1466,8 +1466,30 @@ func TestSendCmd_ChannelFlag(t *testing.T) {
 	c := client.NewWithConfig(server.URL, "test-token", nil)
 	opts := &sendOptions{channel: "C123", simple: true}
 
-	// When --channel is provided, the first positional arg is text
 	err := runSend("C123", "Hello", opts, c)
+	require.NoError(t, err)
+}
+
+func TestSendCmd_ChannelFlagWithMultipleArgs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]interface{}
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		assert.Equal(t, "C123", body["channel"])
+		assert.Equal(t, "Hello World", body["text"])
+
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"ts": "1234567890.123456",
+		})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	// Simulate what RunE does: join args when --channel is set
+	opts := &sendOptions{channel: "C123", simple: true}
+	text := strings.Join([]string{"Hello", "World"}, " ")
+
+	err := runSend("C123", text, opts, c)
 	require.NoError(t, err)
 }
 

--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -82,8 +83,8 @@ The channel can also be specified via --channel instead of as a positional argum
 			text := ""
 			switch {
 			case channel != "" && len(args) > 0:
-				// --channel provided, all positional args are text
-				text = args[0]
+				// --channel provided, positional args are text
+				text = strings.Join(args, " ")
 			case channel != "":
 				// --channel provided, no positional args
 			case len(args) >= 1:


### PR DESCRIPTION
## Summary

Adds `--channel` as an optional flag alternative to the positional channel argument on `messages send`. Both forms are equivalent:

```bash
slck messages send general "Hello"
slck messages send --channel general "Hello"
```

When `--channel` is provided, all positional arguments are treated as text. If neither `--channel` nor a positional channel is provided, the command returns an error.

## Motivation

The positional-only syntax isn't always intuitive, especially for AI tooling and MCP integrations that naturally reach for `--channel`. This makes the interface more flexible without changing existing behavior.

## Changes

- `send.go`: Add `channel` field to `sendOptions`, register `--channel` flag, update `RunE` to resolve channel from flag or positional arg
- `messages_test.go`: Add `TestSendCmd_ChannelFlag` and `TestSendCmd_NoChannelError`
