### PR TITLE
docs: catch up README, CHANGELOG, and integration tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,11 @@
 ## [Unreleased]
 
 ### Added
+- Idempotent handling for react, unreact, archive, unarchive, and invite commands (#130)
+- `--channel` flag for `messages send` as alternative to positional argument (#126)
+- `emoji list` command for listing custom workspace emoji (#125)
+- `files download` command for downloading files by ID or URL (#122)
+- Files field in message JSON output (#120)
 - `whoami` command for quick identity check (#101)
 - Channel name resolution - accept channel names in addition to IDs (#102)
 - File upload support in `messages send` command (#96)
@@ -22,6 +27,7 @@
 * Module path migrated to `github.com/open-cli-collective/slack-chat-api` ([#76](https://github.com/open-cli-collective/slack-chat-api/pull/76))
 
 ### Fixed
+- Split Block Kit sections exceeding 3000-char limit (#123)
 - Chocolatey install script GitHub releases URL (#88)
 - Unescape shell-escaped exclamation marks in message text ([#47](https://github.com/open-cli-collective/slack-chat-api/pull/47))
 

--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ This means environment variables always override stored credentials, allowing au
            "channels:manage",
            "channels:read",
            "chat:write",
+           "emoji:read",
+           "files:read",
            "groups:history",
            "groups:read",
            "reactions:write",
@@ -206,6 +208,8 @@ This means environment variables always override stored credentials, allowing au
          - "channels:manage"
          - "channels:read"
          - "chat:write"
+         - "emoji:read"
+         - "files:read"
          - "groups:history"
          - "groups:read"
          - "reactions:write"
@@ -268,6 +272,8 @@ The manifest above includes these scopes:
 | `channels:history` | Read message history from public channels |
 | `channels:manage` | Create, archive, set topic/purpose, invite users |
 | `chat:write` | Send, update, delete messages |
+| `emoji:read` | List custom workspace emoji |
+| `files:read` | Download files, get file info |
 | `groups:read` | List private channels |
 | `groups:history` | Read message history from private channels |
 | `reactions:write` | Add/remove reactions |
@@ -426,6 +432,9 @@ slck users search "bot" --include-bots
 # Send a message (uses Block Kit formatting by default)
 slck messages send C1234567890 "Hello, *world*!"
 
+# Send using --channel flag (alternative to positional arg)
+slck messages send --channel general "Hello team"
+
 # Send from stdin (use "-" as text argument)
 echo "Hello from stdin" | slck messages send C1234567890 -
 cat message.txt | slck messages send C1234567890 -
@@ -438,6 +447,10 @@ slck messages send C1234567890 "Fallback" --blocks '[{"type":"section","text":{"
 
 # Reply in a thread
 slck messages send C1234567890 "Thread reply" --thread 1234567890.123456
+
+# Upload files with a message
+slck messages send C1234567890 "Here's the report" --file ./report.csv
+slck messages send C1234567890 --file ./a.csv --file ./b.csv
 
 # Update a message
 slck messages update C1234567890 1234567890.123456 "Updated text"
@@ -465,7 +478,7 @@ slck messages unreact C1234567890 1234567890.123456 thumbsup
 
 | Command | Flags | Description |
 |---------|-------|-------------|
-| `send <channel> <text>` | `--thread`, `--blocks`, `--simple` | Send a message (use `-` for stdin) |
+| `send <channel> <text>` | `--thread`, `--blocks`, `--simple`, `--channel`, `--file` | Send a message (use `-` for stdin) |
 | `update <channel> <ts> <text>` | `--blocks`, `--simple` | Update a message |
 | `delete <channel> <ts>` | `--force` | Delete a message (prompts for confirmation) |
 | `history <channel>` | `--limit`, `--oldest`, `--latest` | Get channel history |
@@ -556,6 +569,48 @@ These flags provide an alternative to using modifiers in the query string:
 slck workspace info
 ```
 
+### Emoji
+
+```bash
+# List custom workspace emoji
+slck emoji list
+
+# Include aliases
+slck emoji list --include-aliases
+```
+
+#### Emoji Command Reference
+
+| Command | Flags | Description |
+|---------|-------|-------------|
+| `list` | `--include-aliases` | List custom workspace emoji |
+
+### Files
+
+```bash
+# Download a file by ID
+slck files download F0AHF3NUSQK
+
+# Download to a specific path
+slck files download F0AHF3NUSQK --output report.pdf
+
+# Download using a Slack file URL
+slck files download "https://files.slack.com/files-pri/T.../F0AHF3NUSQK/file.csv"
+```
+
+#### Files Command Reference
+
+| Command | Flags | Description |
+|---------|-------|-------------|
+| `download <file-id-or-url>` | `--output`, `-O` | Download a Slack file |
+
+### Identity
+
+```bash
+# Show authenticated identity (bot, user, workspace)
+slck whoami
+```
+
 ### Config
 
 ```bash
@@ -628,6 +683,7 @@ Commands have convenient aliases:
 | `users` | `u` |
 | `messages` | `msg`, `m` |
 | `search` | `s` |
+| `emoji` | `e` |
 | `workspace` | `ws`, `team` |
 
 ## Environment Variables

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -29,6 +29,8 @@ In **OAuth & Permissions**, add these **Bot Token Scopes**:
 | `reactions:write` | Add/remove reactions | Part 3 |
 | `channels:manage` | Create, archive, set topic/purpose, invite | Parts 4 & 5 |
 | `groups:write` | Topic/purpose/invite for private channels | Part 4 |
+| `emoji:read` | List custom workspace emoji | Part 7 |
+| `files:read` | Download files, get file info | Part 7 |
 
 **Note:** `channels:manage` is a superset that includes `channels:write.topic` and `channels:write.invites`. You can use the granular scopes instead if you want more limited permissions.
 
@@ -167,6 +169,7 @@ These tests create messages, then clean them up at the end.
 | 2 | `slck messages history $TEST_CHANNEL_ID --limit 1` | Shows your message |
 | 3 | `slck messages send $TEST_CHANNEL_ID "JSON test" -o json` | JSON with `ts` field | (verify only) |
 | 4 | `slck messages send $TEST_CHANNEL_ID "Plain text" --simple` | Message without Block Kit formatting |
+| 5 | `slck messages send --channel $TEST_CHANNEL_ID "Channel flag test"` | "Message sent" (--channel flag alternative) |
 
 ### 3.2 Multiline Message (stdin)
 
@@ -532,6 +535,45 @@ These can be run at any time to verify error handling.
 | 1 | `slck messages send $TEST_CHANNEL_ID "Hello 👋 世界"` | Unicode preserved |
 | 2 | `slck messages send $TEST_CHANNEL_ID 'Test <>&"'"'"' chars'` | Special chars escaped |
 | 3 | `slck channels create my-test-with-hyphens` | Works (clean up after) |
+
+---
+
+## Part 8: Emoji & Files Tests
+
+**Scopes required:** `emoji:read`, `files:read`
+
+These are read-only tests with no side effects.
+
+### 8.1 Emoji List
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 1 | `slck emoji list` | Lists custom emoji names (or "No custom emoji found") |
+| 2 | `slck emoji list --include-aliases` | Includes alias entries (prefixed with `alias:` in JSON) |
+| 3 | `slck emoji list -o json` | Valid JSON map of emoji name → URL |
+
+### 8.2 Files Download
+
+> Requires a known file ID from your workspace. Upload a test file to Slack first, then note its file ID from the message JSON.
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 1 | `slck files download <FILE_ID>` | "Downloaded <name> (<size> bytes) to <path>" |
+| 2 | `slck files download <FILE_ID> --output /tmp/test-download` | File saved to specified path |
+| 3 | `slck files download <FILE_ID> -o json` | JSON with file_id, name, size, path fields |
+
+---
+
+## Part 9: Identity Tests
+
+No additional scopes required (uses `auth.test` which works with any valid token).
+
+### 9.1 Whoami
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 1 | `slck whoami` | Shows Bot name/ID, Workspace name |
+| 2 | `slck whoami -o json` | JSON with bot, workspace fields |
 
 ---
 


### PR DESCRIPTION
## Summary

- Add missing README sections for `emoji list`, `files download`, and `whoami` commands
- Document `--channel` and `--file` flags on `messages send`
- Add `emoji:read` and `files:read` OAuth scopes to app manifest and scopes table
- Add `emoji` → `e` alias to aliases table
- Update CHANGELOG with entries for #120, #122, #123, #125, #126, #130
- Add integration test sections: Part 8 (Emoji & Files), Part 9 (Identity)
- Add `--channel` flag test case to messaging section
- Add `emoji:read` and `files:read` to integration test setup scopes table

## Test plan

- [x] No code changes — docs only
- [ ] Review README for accuracy against actual CLI behavior
- [ ] Verify CHANGELOG entries reference correct PR numbers