### PR TITLE
ci: add continue-on-error to linux-packages dispatch job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -333,6 +333,7 @@ jobs:
   linux-packages:
     needs: goreleaser
     runs-on: ubuntu-latest
+    continue-on-error: true
     steps:
       - name: Trigger linux-packages repo update
         uses: peter-evans/repository-dispatch@v3


### PR DESCRIPTION
## Summary

- Add `continue-on-error: true` to the `linux-packages` job in `release.yml`
- Prevents dispatch failures from blocking the primary release workflow

Closes #132

## Test plan

- [ ] Verify workflow YAML is valid
- [ ] Next release should show linux-packages as non-blocking