### PR TITLE
fix(messages): remove text truncation from thread command

### DIFF
--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -43,6 +43,12 @@ func formatTimestamp(ts string) string {
 	return t.Format("2006-01-02 15:04")
 }
 
+// flatten replaces newlines with spaces without truncating.
+// Used by detail views (thread) where full content should be visible.
+func flatten(s string) string {
+	return strings.ReplaceAll(s, "\n", " ")
+}
+
 // truncate shortens a string to maxLen, replacing newlines with spaces
 func truncate(s string, maxLen int) string {
 	// Replace newlines with spaces

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -66,6 +66,54 @@ func TestFormatTimestamp(t *testing.T) {
 	}
 }
 
+func TestFlatten(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "no newlines",
+			input:    "Hello World",
+			expected: "Hello World",
+		},
+		{
+			name:     "single newline",
+			input:    "Hello\nWorld",
+			expected: "Hello World",
+		},
+		{
+			name:     "multiple newlines",
+			input:    "Line1\nLine2\nLine3",
+			expected: "Line1 Line2 Line3",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "long string preserved",
+			input:    "This is a very long message that exceeds eighty characters and should not be truncated at all by the flatten function",
+			expected: "This is a very long message that exceeds eighty characters and should not be truncated at all by the flatten function",
+		},
+		{
+			name:     "long string with newlines preserved",
+			input:    "First line\nSecond line that is quite long\nThird line with more content that pushes past eighty characters total",
+			expected: "First line Second line that is quite long Third line with more content that pushes past eighty characters total",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := flatten(tt.input)
+			if result != tt.expected {
+				t.Errorf("flatten(%q) = %q, expected %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestTruncate(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -64,7 +64,7 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 	resolver := client.NewUserResolver(c)
 	for _, m := range messages {
 		ts := formatTimestamp(m.TS)
-		text := truncate(resolver.ResolveMentions(m.Text), 80)
+		text := flatten(resolver.ResolveMentions(m.Text))
 		name := resolver.Resolve(m.User)
 		output.Printf("[%s] %s: %s\n", ts, name, text)
 	}


### PR DESCRIPTION
## Summary
- Thread command was hard-truncating messages at 80 characters in text output, forcing users to use `--output json` to read full content
- Added `flatten()` helper (newlines→spaces, no truncation) for detail views; thread uses it instead of `truncate()`
- History command retains 80-char truncation (appropriate for list view)

Closes #128

## Test plan
- [x] `TestFlatten` — 6 cases covering empty, short, long, and multiline strings
- [x] Existing `TestTruncate` still passes (history unaffected)
- [x] `make lint` clean