### PR TITLE
feat(messages): add --since flag to thread command

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -586,7 +586,7 @@ func (c *Client) GetChannelHistory(channel string, limit int, oldest, latest str
 }
 
 // GetThreadReplies returns replies to a thread (handles pagination to reach requested limit)
-func (c *Client) GetThreadReplies(channel, threadTS string, limit int) ([]Message, error) {
+func (c *Client) GetThreadReplies(channel, threadTS string, limit int, oldest string) ([]Message, error) {
 	var allMessages []Message
 	cursor := ""
 	remaining := limit
@@ -601,6 +601,9 @@ func (c *Client) GetThreadReplies(channel, threadTS string, limit int) ([]Messag
 			batchSize = 200
 		}
 		params.Set("limit", fmt.Sprintf("%d", batchSize))
+		if oldest != "" {
+			params.Set("oldest", oldest)
+		}
 		if cursor != "" {
 			params.Set("cursor", cursor)
 		}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -473,13 +473,42 @@ func TestClient_GetThreadReplies_Success(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	messages, err := client.GetThreadReplies("C123", "1234567890.123456", 100)
+	messages, err := client.GetThreadReplies("C123", "1234567890.123456", 100, "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(messages) != 2 {
 		t.Errorf("expected 2 messages, got %d", len(messages))
+	}
+}
+
+func TestClient_GetThreadReplies_WithOldest(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("oldest") != "1700000050.000000" {
+			t.Errorf("expected oldest=1700000050.000000, got %s", r.URL.Query().Get("oldest"))
+		}
+
+		resp := map[string]interface{}{
+			"ok": true,
+			"messages": []map[string]interface{}{
+				{"ts": "1700000060.000000", "text": "New reply"},
+			},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	messages, err := client.GetThreadReplies("C123", "1700000000.000000", 100, "1700000050.000000")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(messages))
 	}
 }
 
@@ -511,7 +540,7 @@ func TestClient_GetThreadReplies_WithReactions(t *testing.T) {
 	defer server.Close()
 
 	client := NewWithConfig(server.URL, "test-token", nil)
-	messages, err := client.GetThreadReplies("C123", "1234567890.123456", 100)
+	messages, err := client.GetThreadReplies("C123", "1234567890.123456", 100, "")
 
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -10,6 +10,7 @@ import (
 
 type threadOptions struct {
 	limit int
+	since string
 }
 
 func newThreadCmd() *cobra.Command {
@@ -25,6 +26,7 @@ func newThreadCmd() *cobra.Command {
 	}
 
 	cmd.Flags().IntVar(&opts.limit, "limit", 100, "Maximum replies to return")
+	cmd.Flags().StringVar(&opts.since, "since", "", "Only return messages after this timestamp")
 
 	return cmd
 }
@@ -47,7 +49,7 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 		return err
 	}
 
-	messages, err := c.GetThreadReplies(channelID, threadTS, opts.limit)
+	messages, err := c.GetThreadReplies(channelID, threadTS, opts.limit, opts.since)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary
- Adds `--since <timestamp>` flag to `slck messages thread` that maps to Slack's `oldest` parameter on `conversations.replies`
- Only returns messages with `ts` greater than the given value — useful for polling threads without refetching all history
- Consistent with existing `--oldest` flag on `messages history`

Closes #127

## Test plan
- [x] `TestClient_GetThreadReplies_WithOldest` — verifies `oldest` param is sent to API
- [x] Existing `GetThreadReplies` tests updated and passing
- [x] `make lint` clean