### PR TITLE
fix(messages): surface edited message metadata and text

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -243,6 +243,12 @@ type File struct {
 	Permalink          string `json:"permalink,omitempty"`
 }
 
+// Edited represents the edit metadata for an edited Slack message
+type Edited struct {
+	User string `json:"user"`
+	TS   string `json:"ts"`
+}
+
 // Message represents a Slack message
 type Message struct {
 	Type       string     `json:"type"`
@@ -251,6 +257,7 @@ type Message struct {
 	TS         string     `json:"ts"`
 	ThreadTS   string     `json:"thread_ts,omitempty"`
 	ReplyCount int        `json:"reply_count,omitempty"`
+	Edited     *Edited    `json:"edited,omitempty"`
 	Reactions  []Reaction `json:"reactions,omitempty"`
 	Files      []File     `json:"files,omitempty"`
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -572,6 +572,63 @@ func TestClient_GetThreadReplies_WithReactions(t *testing.T) {
 	}
 }
 
+func TestClient_GetThreadReplies_WithEdited(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{
+			"ok": true,
+			"messages": []map[string]interface{}{
+				{
+					"ts":   "1234567890.123456",
+					"text": "Updated text after edit",
+					"user": "U123",
+					"edited": map[string]interface{}{
+						"user": "U123",
+						"ts":   "1234567891.000000",
+					},
+				},
+				{
+					"ts":   "1234567890.123457",
+					"text": "Unedited reply",
+					"user": "U456",
+				},
+			},
+			"response_metadata": map[string]string{"next_cursor": ""},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	messages, err := client.GetThreadReplies("C123", "1234567890.123456", 100, "")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(messages))
+	}
+
+	// First message should have edited metadata
+	if messages[0].Edited == nil {
+		t.Fatal("expected edited metadata on first message, got nil")
+	}
+	if messages[0].Edited.User != "U123" {
+		t.Errorf("expected edited user 'U123', got %s", messages[0].Edited.User)
+	}
+	if messages[0].Edited.TS != "1234567891.000000" {
+		t.Errorf("expected edited ts '1234567891.000000', got %s", messages[0].Edited.TS)
+	}
+	if messages[0].Text != "Updated text after edit" {
+		t.Errorf("expected updated text, got %s", messages[0].Text)
+	}
+
+	// Second message should not have edited metadata
+	if messages[1].Edited != nil {
+		t.Errorf("expected no edited metadata on second message, got %+v", messages[1].Edited)
+	}
+}
+
 func TestClient_GetChannelHistory_WithReactions(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]interface{}{

--- a/internal/cmd/messages/history.go
+++ b/internal/cmd/messages/history.go
@@ -66,7 +66,11 @@ func runHistory(channel string, opts *historyOptions, c *client.Client) error {
 		ts := formatTimestamp(m.TS)
 		text := truncate(resolver.ResolveMentions(m.Text), 80)
 		name := resolver.Resolve(m.User)
-		output.Printf("[%s] %s: %s\n", ts, name, text)
+		edited := ""
+		if m.Edited != nil {
+			edited = " [edited]"
+		}
+		output.Printf("[%s] %s: %s%s\n", ts, name, text, edited)
 	}
 
 	return nil

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -68,7 +68,11 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 		ts := formatTimestamp(m.TS)
 		text := flatten(resolver.ResolveMentions(m.Text))
 		name := resolver.Resolve(m.User)
-		output.Printf("[%s] %s: %s\n", ts, name, text)
+		edited := ""
+		if m.Edited != nil {
+			edited = " [edited]"
+		}
+		output.Printf("[%s] %s: %s%s\n", ts, name, text, edited)
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Added `Edited` struct (user + ts) to `Message` type — previously silently dropped during JSON unmarshal
- Thread and history text output now shows `[edited]` indicator for modified messages
- JSON output includes the full `edited` metadata object

Closes #117

## Test plan
- [x] `TestClient_GetThreadReplies_WithEdited` — verifies edited metadata is deserialized correctly
- [x] Verifies unedited messages have nil `Edited` field
- [x] All existing tests passing
- [x] `make lint` clean