### PR TITLE
feat(canvas): add canvas create, edit, and delete commands

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -1010,3 +1010,80 @@ func (c *Client) SearchAll(query string, count, page int, sort, sortDir string, 
 	result.Query = query
 	return &result, nil
 }
+
+// CreateCanvas creates a standalone canvas with markdown content
+func (c *Client) CreateCanvas(title, markdown string) (string, error) {
+	data := map[string]interface{}{
+		"title": title,
+		"document_content": map[string]string{
+			"type":     "markdown",
+			"markdown": markdown,
+		},
+	}
+
+	body, err := c.post("canvases.create", data)
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		CanvasID string `json:"canvas_id"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+	return result.CanvasID, nil
+}
+
+// CreateChannelCanvas creates a canvas pinned to a channel
+func (c *Client) CreateChannelCanvas(channelID, markdown string) (string, error) {
+	data := map[string]interface{}{
+		"channel_id": channelID,
+		"document_content": map[string]string{
+			"type":     "markdown",
+			"markdown": markdown,
+		},
+	}
+
+	body, err := c.post("conversations.canvases.create", data)
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		CanvasID string `json:"canvas_id"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+	return result.CanvasID, nil
+}
+
+// EditCanvas replaces the content of an existing canvas
+func (c *Client) EditCanvas(canvasID, markdown string) error {
+	data := map[string]interface{}{
+		"canvas_id": canvasID,
+		"changes": []map[string]interface{}{
+			{
+				"operation": "replace",
+				"document_content": map[string]string{
+					"type":     "markdown",
+					"markdown": markdown,
+				},
+			},
+		},
+	}
+
+	_, err := c.post("canvases.edit", data)
+	return err
+}
+
+// DeleteCanvas deletes a canvas
+func (c *Client) DeleteCanvas(canvasID string) error {
+	data := map[string]interface{}{
+		"canvas_id": canvasID,
+	}
+
+	_, err := c.post("canvases.delete", data)
+	return err
+}

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1358,3 +1358,99 @@ func TestClient_SearchAll_Success(t *testing.T) {
 		t.Errorf("expected files total 3, got %d", result.Files.Total)
 	}
 }
+
+func TestClient_CreateCanvas_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "canvases.create") {
+			t.Errorf("expected path canvases.create, got %s", r.URL.Path)
+		}
+
+		resp := map[string]interface{}{
+			"ok":        true,
+			"canvas_id": "F12345ABC",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	canvasID, err := client.CreateCanvas("Test Canvas", "# Hello")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if canvasID != "F12345ABC" {
+		t.Errorf("expected canvas ID F12345ABC, got %s", canvasID)
+	}
+}
+
+func TestClient_CreateChannelCanvas_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "conversations.canvases.create") {
+			t.Errorf("expected path conversations.canvases.create, got %s", r.URL.Path)
+		}
+
+		resp := map[string]interface{}{
+			"ok":        true,
+			"canvas_id": "F67890DEF",
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	canvasID, err := client.CreateChannelCanvas("C123", "# Channel Doc")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if canvasID != "F67890DEF" {
+		t.Errorf("expected canvas ID F67890DEF, got %s", canvasID)
+	}
+}
+
+func TestClient_EditCanvas_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "canvases.edit") {
+			t.Errorf("expected path canvases.edit, got %s", r.URL.Path)
+		}
+
+		resp := map[string]interface{}{
+			"ok": true,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	err := client.EditCanvas("F12345ABC", "# Updated")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestClient_DeleteCanvas_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "canvases.delete") {
+			t.Errorf("expected path canvases.delete, got %s", r.URL.Path)
+		}
+
+		resp := map[string]interface{}{
+			"ok": true,
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	err := client.DeleteCanvas("F12345ABC")
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/cmd/canvas/canvas.go
+++ b/internal/cmd/canvas/canvas.go
@@ -1,0 +1,20 @@
+package canvas
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// NewCmd creates the canvas command with all subcommands
+func NewCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "canvas",
+		Aliases: []string{"cv"},
+		Short:   "Manage Slack canvases",
+	}
+
+	cmd.AddCommand(newCreateCmd())
+	cmd.AddCommand(newEditCmd())
+	cmd.AddCommand(newDeleteCmd())
+
+	return cmd
+}

--- a/internal/cmd/canvas/canvas_test.go
+++ b/internal/cmd/canvas/canvas_test.go
@@ -1,0 +1,91 @@
+package canvas
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestResolveContent_Text(t *testing.T) {
+	content, err := resolveContent("# Hello", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "# Hello" {
+		t.Errorf("expected '# Hello', got %q", content)
+	}
+}
+
+func TestResolveContent_Stdin(t *testing.T) {
+	r := strings.NewReader("# From stdin")
+	content, err := resolveContent("", "-", r)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "# From stdin" {
+		t.Errorf("expected '# From stdin', got %q", content)
+	}
+}
+
+func TestResolveContent_BothTextAndFile(t *testing.T) {
+	_, err := resolveContent("text", "file.md", nil)
+	if err == nil {
+		t.Fatal("expected error when both text and file provided")
+	}
+}
+
+func TestResolveContent_Empty(t *testing.T) {
+	content, err := resolveContent("", "", nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "" {
+		t.Errorf("expected empty string, got %q", content)
+	}
+}
+
+func TestResolveContent_File(t *testing.T) {
+	// Create a temp file
+	dir := t.TempDir()
+	path := dir + "/test.md"
+	if err := writeTestFile(path, "# From file"); err != nil {
+		t.Fatalf("failed to create test file: %v", err)
+	}
+	content, err := resolveContent("", path, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if content != "# From file" {
+		t.Errorf("expected '# From file', got %q", content)
+	}
+}
+
+func TestResolveContent_FileNotFound(t *testing.T) {
+	_, err := resolveContent("", "/nonexistent/file.md", nil)
+	if err == nil {
+		t.Fatal("expected error for nonexistent file")
+	}
+}
+
+func TestRunCreate_NoContent(t *testing.T) {
+	opts := &createOptions{title: "Test"}
+	err := runCreate(opts, nil)
+	if err == nil {
+		t.Fatal("expected error when no content provided")
+	}
+}
+
+func TestRunCreate_StandaloneNoTitle(t *testing.T) {
+	opts := &createOptions{text: "# Content"}
+	// This should fail because title is required for standalone canvases
+	// but we can't test with a nil client — the client.New() will fail first
+	// Just test that the validation is in place by checking the error
+	err := runCreate(opts, nil)
+	if err == nil {
+		t.Fatal("expected error when no client available")
+	}
+}
+
+func writeTestFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0644)
+}

--- a/internal/cmd/canvas/canvas_test.go
+++ b/internal/cmd/canvas/canvas_test.go
@@ -1,9 +1,14 @@
 package canvas
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 func TestResolveContent_Text(t *testing.T) {
@@ -45,10 +50,9 @@ func TestResolveContent_Empty(t *testing.T) {
 }
 
 func TestResolveContent_File(t *testing.T) {
-	// Create a temp file
 	dir := t.TempDir()
 	path := dir + "/test.md"
-	if err := writeTestFile(path, "# From file"); err != nil {
+	if err := os.WriteFile(path, []byte("# From file"), 0644); err != nil {
 		t.Fatalf("failed to create test file: %v", err)
 	}
 	content, err := resolveContent("", path, nil)
@@ -73,19 +77,119 @@ func TestRunCreate_NoContent(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error when no content provided")
 	}
+	if !strings.Contains(err.Error(), "content required") {
+		t.Errorf("expected content required error, got: %v", err)
+	}
 }
 
 func TestRunCreate_StandaloneNoTitle(t *testing.T) {
 	opts := &createOptions{text: "# Content"}
-	// This should fail because title is required for standalone canvases
-	// but we can't test with a nil client — the client.New() will fail first
-	// Just test that the validation is in place by checking the error
 	err := runCreate(opts, nil)
 	if err == nil {
-		t.Fatal("expected error when no client available")
+		t.Fatal("expected error when no title for standalone canvas")
+	}
+	if !strings.Contains(err.Error(), "--title is required") {
+		t.Errorf("expected title required error, got: %v", err)
 	}
 }
 
-func writeTestFile(path, content string) error {
-	return os.WriteFile(path, []byte(content), 0644)
+func TestRunCreate_TitleWithChannel(t *testing.T) {
+	opts := &createOptions{text: "# Content", title: "Test", channel: "C123"}
+	err := runCreate(opts, nil)
+	if err == nil {
+		t.Fatal("expected error when title used with channel")
+	}
+	if !strings.Contains(err.Error(), "--title is not used with --channel") {
+		t.Errorf("expected title+channel error, got: %v", err)
+	}
+}
+
+func TestRunCreate_Standalone_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{"ok": true, "canvas_id": "F12345"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &createOptions{title: "Test Canvas", text: "# Hello"}
+	err := runCreate(opts, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunCreate_Channel_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{"ok": true, "canvas_id": "F67890"}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &createOptions{channel: "C12345ABC", text: "# Channel Doc"}
+	err := runCreate(opts, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunEdit_NoContent(t *testing.T) {
+	opts := &editOptions{}
+	err := runEdit("F12345", opts, nil)
+	if err == nil {
+		t.Fatal("expected error when no content provided")
+	}
+	if !strings.Contains(err.Error(), "content required") {
+		t.Errorf("expected content required error, got: %v", err)
+	}
+}
+
+func TestRunEdit_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{"ok": true}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &editOptions{text: "# Updated"}
+	err := runEdit("F12345", opts, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunEdit_Stdin(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{"ok": true}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &editOptions{file: "-", stdin: strings.NewReader("# From stdin")}
+	err := runEdit("F12345", opts, c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestRunDelete_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		resp := map[string]interface{}{"ok": true}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	err := runDelete("F12345", c)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
 }

--- a/internal/cmd/canvas/create.go
+++ b/internal/cmd/canvas/create.go
@@ -1,7 +1,6 @@
 package canvas
 
 import (
-	"bufio"
 	"fmt"
 	"io"
 	"os"
@@ -40,7 +39,7 @@ Create a channel canvas (pinned to channel tab):
 		},
 	}
 
-	cmd.Flags().StringVar(&opts.title, "title", "", "Canvas title")
+	cmd.Flags().StringVar(&opts.title, "title", "", "Canvas title (standalone canvases only)")
 	cmd.Flags().StringVar(&opts.text, "text", "", "Markdown content as inline text")
 	cmd.Flags().StringVar(&opts.file, "file", "", "Read markdown content from file (use - for stdin)")
 	cmd.Flags().StringVar(&opts.channel, "channel", "", "Channel ID to create a channel canvas")
@@ -55,6 +54,14 @@ func runCreate(opts *createOptions, c *client.Client) error {
 	}
 	if markdown == "" {
 		return fmt.Errorf("content required: use --text, --file, or --file -")
+	}
+
+	// Validate flags before client init so users get clear errors without needing a valid token
+	if opts.channel == "" && opts.title == "" {
+		return fmt.Errorf("--title is required for standalone canvases")
+	}
+	if opts.channel != "" && opts.title != "" {
+		return fmt.Errorf("--title is not used with --channel (channel canvases don't have titles)")
 	}
 
 	if c == nil {
@@ -78,10 +85,6 @@ func runCreate(opts *createOptions, c *client.Client) error {
 		}
 		output.Printf("Created channel canvas: %s\n", canvasID)
 		return nil
-	}
-
-	if opts.title == "" {
-		return fmt.Errorf("--title is required for standalone canvases")
 	}
 
 	canvasID, err := c.CreateCanvas(opts.title, markdown)
@@ -124,16 +127,9 @@ func readStdin(r io.Reader) (string, error) {
 	if r == nil {
 		r = os.Stdin
 	}
-	scanner := bufio.NewScanner(r)
-	var lines []byte
-	for scanner.Scan() {
-		if len(lines) > 0 {
-			lines = append(lines, '\n')
-		}
-		lines = append(lines, scanner.Bytes()...)
-	}
-	if err := scanner.Err(); err != nil {
+	data, err := io.ReadAll(r)
+	if err != nil {
 		return "", fmt.Errorf("reading stdin: %w", err)
 	}
-	return string(lines), nil
+	return string(data), nil
 }

--- a/internal/cmd/canvas/create.go
+++ b/internal/cmd/canvas/create.go
@@ -1,0 +1,139 @@
+package canvas
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+type createOptions struct {
+	title   string
+	text    string
+	file    string
+	channel string
+	stdin   io.Reader // For testing
+}
+
+func newCreateCmd() *cobra.Command {
+	opts := &createOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "create",
+		Short: "Create a canvas",
+		Long: `Create a standalone or channel canvas with markdown content.
+
+Provide content via --text, --file, or stdin:
+  slck canvas create --title "Report" --text "# Heading"
+  slck canvas create --title "Report" --file report.md
+  echo "# Report" | slck canvas create --title "Report" --file -
+
+Create a channel canvas (pinned to channel tab):
+  slck canvas create --channel C1234567890 --file runbook.md`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCreate(opts, nil)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.title, "title", "", "Canvas title")
+	cmd.Flags().StringVar(&opts.text, "text", "", "Markdown content as inline text")
+	cmd.Flags().StringVar(&opts.file, "file", "", "Read markdown content from file (use - for stdin)")
+	cmd.Flags().StringVar(&opts.channel, "channel", "", "Channel ID to create a channel canvas")
+
+	return cmd
+}
+
+func runCreate(opts *createOptions, c *client.Client) error {
+	markdown, err := resolveContent(opts.text, opts.file, opts.stdin)
+	if err != nil {
+		return err
+	}
+	if markdown == "" {
+		return fmt.Errorf("content required: use --text, --file, or --file -")
+	}
+
+	if c == nil {
+		c, err = client.New()
+		if err != nil {
+			return err
+		}
+	}
+
+	if opts.channel != "" {
+		channelID, err := c.ResolveChannel(opts.channel)
+		if err != nil {
+			return err
+		}
+		canvasID, err := c.CreateChannelCanvas(channelID, markdown)
+		if err != nil {
+			return client.WrapError("create channel canvas", err)
+		}
+		if output.IsJSON() {
+			return output.PrintJSON(map[string]string{"canvas_id": canvasID, "channel": channelID})
+		}
+		output.Printf("Created channel canvas: %s\n", canvasID)
+		return nil
+	}
+
+	if opts.title == "" {
+		return fmt.Errorf("--title is required for standalone canvases")
+	}
+
+	canvasID, err := c.CreateCanvas(opts.title, markdown)
+	if err != nil {
+		return client.WrapError("create canvas", err)
+	}
+
+	if output.IsJSON() {
+		return output.PrintJSON(map[string]string{"canvas_id": canvasID, "title": opts.title})
+	}
+	output.Printf("Created canvas: %s\n", canvasID)
+	return nil
+}
+
+func resolveContent(text, file string, stdin io.Reader) (string, error) {
+	if text != "" && file != "" {
+		return "", fmt.Errorf("cannot use both --text and --file")
+	}
+
+	if text != "" {
+		return text, nil
+	}
+
+	if file == "-" {
+		return readStdin(stdin)
+	}
+
+	if file != "" {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return "", fmt.Errorf("reading file: %w", err)
+		}
+		return string(data), nil
+	}
+
+	return "", nil
+}
+
+func readStdin(r io.Reader) (string, error) {
+	if r == nil {
+		r = os.Stdin
+	}
+	scanner := bufio.NewScanner(r)
+	var lines []byte
+	for scanner.Scan() {
+		if len(lines) > 0 {
+			lines = append(lines, '\n')
+		}
+		lines = append(lines, scanner.Bytes()...)
+	}
+	if err := scanner.Err(); err != nil {
+		return "", fmt.Errorf("reading stdin: %w", err)
+	}
+	return string(lines), nil
+}

--- a/internal/cmd/canvas/delete.go
+++ b/internal/cmd/canvas/delete.go
@@ -1,0 +1,41 @@
+package canvas
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+func newDeleteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "delete <canvas-id>",
+		Short: "Delete a canvas",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runDelete(args[0], nil)
+		},
+	}
+
+	return cmd
+}
+
+func runDelete(canvasID string, c *client.Client) error {
+	if c == nil {
+		var err error
+		c, err = client.New()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := c.DeleteCanvas(canvasID); err != nil {
+		return client.WrapError("delete canvas", err)
+	}
+
+	if output.IsJSON() {
+		return output.PrintJSON(map[string]string{"canvas_id": canvasID, "status": "deleted"})
+	}
+	output.Printf("Deleted canvas: %s\n", canvasID)
+	return nil
+}

--- a/internal/cmd/canvas/edit.go
+++ b/internal/cmd/canvas/edit.go
@@ -2,6 +2,7 @@ package canvas
 
 import (
 	"fmt"
+	"io"
 
 	"github.com/spf13/cobra"
 
@@ -10,8 +11,9 @@ import (
 )
 
 type editOptions struct {
-	text string
-	file string
+	text  string
+	file  string
+	stdin io.Reader // For testing
 }
 
 func newEditCmd() *cobra.Command {
@@ -38,12 +40,12 @@ func newEditCmd() *cobra.Command {
 }
 
 func runEdit(canvasID string, opts *editOptions, c *client.Client) error {
-	markdown, err := resolveContent(opts.text, opts.file, nil)
+	markdown, err := resolveContent(opts.text, opts.file, opts.stdin)
 	if err != nil {
 		return err
 	}
 	if markdown == "" {
-		return fmt.Errorf("content required: use --text or --file")
+		return fmt.Errorf("content required: use --text, --file, or --file -")
 	}
 
 	if c == nil {

--- a/internal/cmd/canvas/edit.go
+++ b/internal/cmd/canvas/edit.go
@@ -1,0 +1,65 @@
+package canvas
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+type editOptions struct {
+	text string
+	file string
+}
+
+func newEditCmd() *cobra.Command {
+	opts := &editOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "edit <canvas-id>",
+		Short: "Edit a canvas",
+		Long: `Replace the content of an existing canvas with new markdown.
+
+  slck canvas edit F12345 --text "# Updated content"
+  slck canvas edit F12345 --file updated.md
+  echo "# New content" | slck canvas edit F12345 --file -`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runEdit(args[0], opts, nil)
+		},
+	}
+
+	cmd.Flags().StringVar(&opts.text, "text", "", "Markdown content as inline text")
+	cmd.Flags().StringVar(&opts.file, "file", "", "Read markdown content from file (use - for stdin)")
+
+	return cmd
+}
+
+func runEdit(canvasID string, opts *editOptions, c *client.Client) error {
+	markdown, err := resolveContent(opts.text, opts.file, nil)
+	if err != nil {
+		return err
+	}
+	if markdown == "" {
+		return fmt.Errorf("content required: use --text or --file")
+	}
+
+	if c == nil {
+		c, err = client.New()
+		if err != nil {
+			return err
+		}
+	}
+
+	if err := c.EditCanvas(canvasID, markdown); err != nil {
+		return client.WrapError("edit canvas", err)
+	}
+
+	if output.IsJSON() {
+		return output.PrintJSON(map[string]string{"canvas_id": canvasID, "status": "updated"})
+	}
+	output.Printf("Updated canvas: %s\n", canvasID)
+	return nil
+}

--- a/internal/cmd/root/root.go
+++ b/internal/cmd/root/root.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/cmd/canvas"
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/channels"
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/config"
 	"github.com/open-cli-collective/slack-chat-api/internal/cmd/emoji"
@@ -79,6 +80,7 @@ func init() {
 	rootCmd.SetVersionTemplate("slck " + version.Info() + "\n")
 
 	// Add subcommands
+	rootCmd.AddCommand(canvas.NewCmd())
 	rootCmd.AddCommand(channels.NewCmd())
 	rootCmd.AddCommand(users.NewCmd())
 	rootCmd.AddCommand(messages.NewCmd())


### PR DESCRIPTION
## Summary
- New `slck canvas` command group (`cv` alias) for managing Slack Canvases
- `canvas create` — standalone (`--title` required) or channel canvases (`--channel`), content via `--text`, `--file`, or stdin (`--file -`)
- `canvas edit <canvas-id>` — replace canvas content
- `canvas delete <canvas-id>` — delete a canvas
- Client methods for `canvases.create`, `conversations.canvases.create`, `canvases.edit`, `canvases.delete`

Closes #116

## Test plan
- [x] Client tests: `CreateCanvas`, `CreateChannelCanvas`, `EditCanvas`, `DeleteCanvas`
- [x] Command tests: `resolveContent` (text, stdin, file, error cases), `runCreate` validation
- [x] `make build`, `make test`, `make lint` all pass