### PR TITLE
docs: update README, CHANGELOG, and integration tests for #134-#137

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## [Unreleased]
 
 ### Added
+- `canvas` command group: create, edit, and delete Slack Canvases (#137)
+- `--since` flag for `messages thread` to filter replies by timestamp (#135)
+- `edited` metadata field on messages with `[edited]` text indicator (#136)
 - Idempotent handling for react, unreact, archive, unarchive, and invite commands (#130)
 - `--channel` flag for `messages send` as alternative to positional argument (#126)
 - `emoji list` command for listing custom workspace emoji (#125)
@@ -27,6 +30,7 @@
 * Module path migrated to `github.com/open-cli-collective/slack-chat-api` ([#76](https://github.com/open-cli-collective/slack-chat-api/pull/76))
 
 ### Fixed
+- `messages thread` text output no longer truncates at 80 characters (#134)
 - Split Block Kit sections exceeding 3000-char limit (#123)
 - Chocolatey install script GitHub releases URL (#88)
 - Unescape shell-escaped exclamation marks in message text ([#47](https://github.com/open-cli-collective/slack-chat-api/pull/47))

--- a/README.md
+++ b/README.md
@@ -468,6 +468,7 @@ slck messages history C1234567890 --latest 1234567890.000000  # Before this time
 # Get thread replies
 slck messages thread C1234567890 1234567890.123456
 slck messages thread C1234567890 1234567890.123456 --limit 50
+slck messages thread C1234567890 1234567890.123456 --since 1234567890.000000  # Only newer replies
 
 # Add/remove reactions
 slck messages react C1234567890 1234567890.123456 thumbsup
@@ -482,7 +483,7 @@ slck messages unreact C1234567890 1234567890.123456 thumbsup
 | `update <channel> <ts> <text>` | `--blocks`, `--simple` | Update a message |
 | `delete <channel> <ts>` | `--force` | Delete a message (prompts for confirmation) |
 | `history <channel>` | `--limit`, `--oldest`, `--latest` | Get channel history |
-| `thread <channel> <ts>` | `--limit` | Get thread replies |
+| `thread <channel> <ts>` | `--limit`, `--since` | Get thread replies |
 | `react <channel> <ts> <emoji>` | | Add reaction |
 | `unreact <channel> <ts> <emoji>` | | Remove reaction |
 
@@ -604,6 +605,35 @@ slck files download "https://files.slack.com/files-pri/T.../F0AHF3NUSQK/file.csv
 |---------|-------|-------------|
 | `download <file-id-or-url>` | `--output`, `-O` | Download a Slack file |
 
+### Canvas
+
+```bash
+# Create a standalone canvas
+slck canvas create --title "Sprint Review" --text "# Sprint Review\n\nContent here"
+slck canvas create --title "Report" --file report.md
+echo "# Report" | slck canvas create --title "Report" --file -
+
+# Create a channel canvas (pinned to channel tab)
+slck canvas create --channel C1234567890 --file runbook.md
+
+# Edit a canvas
+slck canvas edit F12345ABC --text "# Updated content"
+slck canvas edit F12345ABC --file updated.md
+
+# Delete a canvas
+slck canvas delete F12345ABC
+```
+
+#### Canvas Command Reference
+
+| Command | Flags | Description |
+|---------|-------|-------------|
+| `create` | `--title`, `--text`, `--file`, `--channel` | Create a standalone or channel canvas |
+| `edit <canvas-id>` | `--text`, `--file` | Replace canvas content |
+| `delete <canvas-id>` | | Delete a canvas |
+
+> **Note:** Canvas commands require additional Slack app scopes not included in the default manifest. See [Slack Canvas API docs](https://docs.slack.dev/surfaces/canvases/) for required scopes.
+
 ### Identity
 
 ```bash
@@ -679,6 +709,7 @@ Commands have convenient aliases:
 
 | Command | Aliases |
 |---------|---------|
+| `canvas` | `cv` |
 | `channels` | `ch` |
 | `users` | `u` |
 | `messages` | `msg`, `m` |

--- a/integration-tests.md
+++ b/integration-tests.md
@@ -196,8 +196,9 @@ Using **TS₁** from step 3.1:
 | Step | Command | Expected | Capture |
 |------|---------|----------|---------|
 | 1 | `slck messages send $TEST_CHANNEL_ID "Thread reply" --thread <TS₁>` | "Message sent" as thread reply | **Save TS₂** |
-| 2 | `slck messages thread $TEST_CHANNEL_ID <TS₁>` | Shows parent + reply |
+| 2 | `slck messages thread $TEST_CHANNEL_ID <TS₁>` | Shows parent + reply, full text (not truncated) |
 | 3 | `slck messages thread $TEST_CHANNEL_ID <TS₁> -o json` | JSON array of thread messages |
+| 4 | `slck messages thread $TEST_CHANNEL_ID <TS₁> --since <TS₁>` | Only replies after TS₁ (may exclude parent) |
 
 ### 3.5 Update Message
 
@@ -206,7 +207,9 @@ Using **TS₁** from step 3.1:
 | Step | Command | Expected |
 |------|---------|----------|
 | 1 | `slck messages update $TEST_CHANNEL_ID <TS₁> "Updated message text"` | "Message updated" |
-| 2 | `slck messages history $TEST_CHANNEL_ID --limit 1` | Shows updated text |
+| 2 | `slck messages history $TEST_CHANNEL_ID --limit 1` | Shows updated text with `[edited]` suffix |
+| 3 | `slck messages thread $TEST_CHANNEL_ID <TS₁>` | Updated message shows `[edited]` suffix |
+| 4 | `slck messages thread $TEST_CHANNEL_ID <TS₁> -o json` | Updated message has `"edited"` object with `user` and `ts` |
 
 ### 3.6 Cleanup: Delete Messages
 
@@ -577,6 +580,59 @@ No additional scopes required (uses `auth.test` which works with any valid token
 
 ---
 
+## Part 10: Canvas Tests
+
+**Scopes required:** Canvas API scopes (see [Slack Canvas API docs](https://docs.slack.dev/surfaces/canvases/))
+
+These tests create, edit, and delete canvases. Cleanup is included.
+
+### 10.1 Create Standalone Canvas
+
+| Step | Command | Expected | Capture |
+|------|---------|----------|---------|
+| 1 | `slck canvas create --title "Test Canvas" --text "# Hello\n\nIntegration test"` | "Created canvas: F..." | **Save CANVAS_ID₁** |
+| 2 | `slck canvas create --title "Test Canvas" --text "# Hello" -o json` | JSON with `canvas_id` and `title` | (verify only) |
+
+### 10.2 Create Canvas from File
+
+| Step | Command | Expected | Capture |
+|------|---------|----------|---------|
+| 1 | `echo "# From stdin" \| slck canvas create --title "Stdin Canvas" --file -` | "Created canvas: F..." | **Save CANVAS_ID₂** |
+
+### 10.3 Create Channel Canvas
+
+| Step | Command | Expected | Capture |
+|------|---------|----------|---------|
+| 1 | `slck canvas create --channel $TEST_CHANNEL_ID --text "# Channel Doc"` | "Created channel canvas: F..." | **Save CANVAS_ID₃** |
+
+### 10.4 Edit Canvas
+
+Using **CANVAS_ID₁** from step 10.1:
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 1 | `slck canvas edit <CANVAS_ID₁> --text "# Updated\n\nNew content"` | "Updated canvas: F..." |
+| 2 | `slck canvas edit <CANVAS_ID₁> --text "# Updated again" -o json` | JSON with `canvas_id` and `status: "updated"` |
+
+### 10.5 Error Cases
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 1 | `slck canvas create --text "no title"` | Error: `--title is required for standalone canvases` |
+| 2 | `slck canvas create --title "both" --channel C123 --text "x"` | Error: `--title is not used with --channel` |
+| 3 | `slck canvas create --title "no content"` | Error: `content required` |
+| 4 | `slck canvas edit F12345 ` | Error: `content required` |
+
+### 10.6 Cleanup: Delete Canvases
+
+| Step | Command | Expected |
+|------|---------|----------|
+| 1 | `slck canvas delete <CANVAS_ID₁>` | "Deleted canvas: F..." |
+| 2 | `slck canvas delete <CANVAS_ID₂>` | "Deleted canvas: F..." |
+| 3 | `slck canvas delete <CANVAS_ID₃>` | "Deleted canvas: F..." |
+
+---
+
 ## Troubleshooting
 
 | Error | Cause | Solution |
@@ -638,3 +694,4 @@ slck messages history $TEST_CHANNEL_ID --limit 5
 | Part 3 (Messaging) | Test messages TS₁, TS₂ | `messages delete` |
 | Part 3B (Search) | Search test message TS₃ | `messages delete` |
 | Part 5 (Destructive) | Test channels | `channels archive` |
+| Part 10 (Canvas) | Test canvases CANVAS_ID₁–₃ | `canvas delete` |


### PR DESCRIPTION
## Summary
- **README**: Added canvas command section, `--since` flag on thread, canvas alias in aliases table
- **CHANGELOG**: Added entries for canvas (#137), `--since` (#135), edited metadata (#136), truncation fix (#134)
- **integration-tests.md**: Added Part 10 (Canvas Tests), enhanced Part 3.4 with `--since` and full-text verification, enhanced Part 3.5 with `[edited]` indicator checks

## Test plan
- [x] Docs-only change, no code modified