### PR TITLE
feat(messages): validate message length before sending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,20 @@
 # Changelog
 
-## [Unreleased]
+## [3.2.0]
 
 ### Added
 - `canvas` command group: create, edit, and delete Slack Canvases (#137)
 - `--since` flag for `messages thread` to filter replies by timestamp (#135)
 - `edited` metadata field on messages with `[edited]` text indicator (#136)
 - Idempotent handling for react, unreact, archive, unarchive, and invite commands (#130)
+- Pre-send message length validation — errors with helpful alternatives when text exceeds Slack's 40,000 character limit (#139)
+
+### Fixed
+- `messages thread` text output no longer truncates at 80 characters (#134)
+
+## [3.1.35]
+
+### Added
 - `--channel` flag for `messages send` as alternative to positional argument (#126)
 - `emoji list` command for listing custom workspace emoji (#125)
 - `files download` command for downloading files by ID or URL (#122)
@@ -30,7 +38,6 @@
 * Module path migrated to `github.com/open-cli-collective/slack-chat-api` ([#76](https://github.com/open-cli-collective/slack-chat-api/pull/76))
 
 ### Fixed
-- `messages thread` text output no longer truncates at 80 characters (#134)
 - Split Block Kit sections exceeding 3000-char limit (#123)
 - Chocolatey install script GitHub releases URL (#88)
 - Unescape shell-escaped exclamation marks in message text ([#47](https://github.com/open-cli-collective/slack-chat-api/pull/47))

--- a/README.md
+++ b/README.md
@@ -729,6 +729,13 @@ Commands have convenient aliases:
 
 ## Known Limitations
 
+### Message Length Limits
+
+Slack silently truncates messages exceeding 40,000 characters. `slck` validates message length before sending and returns an error with suggestions:
+
+- Upload as a file: `slck messages send C123 --file ./content.txt`
+- Create a canvas: `slck canvas create --title "Title" --file ./content.md`
+
 ### Unarchiving Channels
 
 Bot tokens (`xoxb-`) cannot unarchive channels due to a [Slack API limitation](https://api.slack.com/methods/conversations.unarchive). When a channel is archived, the bot is automatically removed from it, and bot tokens require membership to unarchive.

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -1,6 +1,7 @@
 package messages
 
 import (
+	"fmt"
 	"strconv"
 	"strings"
 	"time"
@@ -71,6 +72,27 @@ func unescapeShellChars(s string) string {
 
 // maxSectionTextLen is Slack's character limit for section block text fields.
 const maxSectionTextLen = 3000
+
+// maxMessageTextLen is Slack's hard limit for the text field of a message.
+// Messages exceeding this limit are silently truncated by Slack.
+// See: https://docs.slack.dev/changelog/2018-truncating-really-long-messages/
+const maxMessageTextLen = 40000
+
+// validateMessageLength checks whether text exceeds Slack's message length limit.
+func validateMessageLength(text string) error {
+	if len(text) <= maxMessageTextLen {
+		return nil
+	}
+	return fmt.Errorf(
+		"message text is %d characters, which exceeds Slack's %d character limit\n"+
+			"The message would be silently truncated by Slack\n\n"+
+			"Alternatives:\n"+
+			"  --file <path>       Upload as a file attachment (no length limit)\n"+
+			"  slck canvas create  Create a Slack canvas instead\n\n"+
+			"To split into multiple messages, write the content to a file and chunk it yourself",
+		len(text), maxMessageTextLen,
+	)
+}
 
 // buildDefaultBlocks creates Block Kit section blocks with mrkdwn formatting.
 // This provides a more refined appearance compared to plain text messages.

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -5,6 +5,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/spf13/cobra"
 )
@@ -79,9 +80,21 @@ const maxSectionTextLen = 3000
 const maxMessageTextLen = 40000
 
 // validateMessageLength checks whether text exceeds Slack's message length limit.
-func validateMessageLength(text string) error {
-	if len(text) <= maxMessageTextLen {
+// The forUpdate parameter controls which alternatives are suggested in the error message.
+func validateMessageLength(text string, forUpdate bool) error {
+	charCount := utf8.RuneCountInString(text)
+	if charCount <= maxMessageTextLen {
 		return nil
+	}
+	if forUpdate {
+		return fmt.Errorf(
+			"message text is %d characters, which exceeds Slack's %d character limit\n"+
+				"The message would be silently truncated by Slack\n\n"+
+				"Alternative:\n"+
+				"  slck canvas create  Create a Slack canvas instead\n\n"+
+				"To split into multiple messages, write the content to a file and chunk it yourself",
+			charCount, maxMessageTextLen,
+		)
 	}
 	return fmt.Errorf(
 		"message text is %d characters, which exceeds Slack's %d character limit\n"+
@@ -90,7 +103,7 @@ func validateMessageLength(text string) error {
 			"  --file <path>       Upload as a file attachment (no length limit)\n"+
 			"  slck canvas create  Create a Slack canvas instead\n\n"+
 			"To split into multiple messages, write the content to a file and chunk it yourself",
-		len(text), maxMessageTextLen,
+		charCount, maxMessageTextLen,
 	)
 }
 

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1595,3 +1595,89 @@ func TestRunSend_FileUpload_NonexistentFile(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "cannot access file")
 }
+
+func TestValidateMessageLength(t *testing.T) {
+	tests := []struct {
+		name    string
+		length  int
+		wantErr bool
+	}{
+		{"under limit", 1000, false},
+		{"at limit", maxMessageTextLen, false},
+		{"over limit by one", maxMessageTextLen + 1, true},
+		{"well over limit", 50000, true},
+		{"empty", 0, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text := strings.Repeat("x", tt.length)
+			err := validateMessageLength(text)
+			if tt.wantErr {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), "exceeds Slack's 40000 character limit")
+				assert.Contains(t, err.Error(), "--file")
+				assert.Contains(t, err.Error(), "canvas create")
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestRunSend_MessageTooLong(t *testing.T) {
+	c := client.NewWithConfig("http://localhost", "test-token", nil)
+	opts := &sendOptions{simple: true}
+
+	longText := strings.Repeat("x", maxMessageTextLen+1)
+	err := runSend("C123", longText, opts, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds Slack's 40000 character limit")
+}
+
+func TestRunUpdate_MessageTooLong(t *testing.T) {
+	c := client.NewWithConfig("http://localhost", "test-token", nil)
+	opts := &updateOptions{simple: true}
+
+	longText := strings.Repeat("x", maxMessageTextLen+1)
+	err := runUpdate("C123", "1234567890.123456", longText, opts, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds Slack's 40000 character limit")
+}
+
+func TestRunSend_FileUpload_LongTextAllowed(t *testing.T) {
+	tmpFile, err := os.CreateTemp(t.TempDir(), "test-upload-*.txt")
+	require.NoError(t, err)
+	_, err = tmpFile.WriteString("content")
+	require.NoError(t, err)
+	tmpFile.Close()
+
+	uploadServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer uploadServer.Close()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(r.URL.Path, "files.getUploadURLExternal"):
+			json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":         true,
+				"upload_url": uploadServer.URL + "/upload",
+				"file_id":    "F123",
+			})
+		case strings.Contains(r.URL.Path, "files.completeUploadExternal"):
+			json.NewEncoder(w).Encode(map[string]interface{}{"ok": true})
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	longText := strings.Repeat("x", maxMessageTextLen+1)
+	opts := &sendOptions{
+		files: []string{tmpFile.Name()},
+	}
+
+	err = runSend("C123456789", longText, opts, c)
+	require.NoError(t, err)
+}

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1599,20 +1599,22 @@ func TestRunSend_FileUpload_NonexistentFile(t *testing.T) {
 func TestValidateMessageLength(t *testing.T) {
 	tests := []struct {
 		name    string
-		length  int
+		text    string
 		wantErr bool
 	}{
-		{"under limit", 1000, false},
-		{"at limit", maxMessageTextLen, false},
-		{"over limit by one", maxMessageTextLen + 1, true},
-		{"well over limit", 50000, true},
-		{"empty", 0, false},
+		{"under limit", strings.Repeat("x", 1000), false},
+		{"at limit", strings.Repeat("x", maxMessageTextLen), false},
+		{"over limit by one", strings.Repeat("x", maxMessageTextLen+1), true},
+		{"well over limit", strings.Repeat("x", 50000), true},
+		{"empty", "", false},
+		{"multi-byte under limit", strings.Repeat("😀", 1000), false},
+		{"multi-byte at limit", strings.Repeat("😀", maxMessageTextLen), false},
+		{"multi-byte over limit", strings.Repeat("😀", maxMessageTextLen+1), true},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			text := strings.Repeat("x", tt.length)
-			err := validateMessageLength(text)
+			err := validateMessageLength(tt.text, false)
 			if tt.wantErr {
 				require.Error(t, err)
 				assert.Contains(t, err.Error(), "exceeds Slack's 40000 character limit")
@@ -1623,6 +1625,14 @@ func TestValidateMessageLength(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestValidateMessageLength_UpdateOmitsFileHint(t *testing.T) {
+	text := strings.Repeat("x", maxMessageTextLen+1)
+	err := validateMessageLength(text, true)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "--file")
+	assert.Contains(t, err.Error(), "canvas create")
 }
 
 func TestRunSend_MessageTooLong(t *testing.T) {

--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -201,7 +201,7 @@ func runSend(channel, text string, opts *sendOptions, c *client.Client) error {
 
 	// Validate message length (file uploads use a different API path with no text limit)
 	if !hasFiles {
-		if err := validateMessageLength(text); err != nil {
+		if err := validateMessageLength(text, false); err != nil {
 			return err
 		}
 	}

--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -199,6 +199,13 @@ func runSend(channel, text string, opts *sendOptions, c *client.Client) error {
 		return fmt.Errorf("message text cannot be empty (or provide blocks via --blocks, --blocks-file, --blocks-stdin, or files via --file)")
 	}
 
+	// Validate message length (file uploads use a different API path with no text limit)
+	if !hasFiles {
+		if err := validateMessageLength(text); err != nil {
+			return err
+		}
+	}
+
 	if c == nil {
 		var err error
 		c, err = client.New()

--- a/internal/cmd/messages/update.go
+++ b/internal/cmd/messages/update.go
@@ -43,7 +43,7 @@ func runUpdate(channel, timestamp, text string, opts *updateOptions, c *client.C
 	// Unescape shell-escaped characters (e.g., \! from zsh)
 	text = unescapeShellChars(text)
 
-	if err := validateMessageLength(text); err != nil {
+	if err := validateMessageLength(text, true); err != nil {
 		return err
 	}
 

--- a/internal/cmd/messages/update.go
+++ b/internal/cmd/messages/update.go
@@ -43,6 +43,10 @@ func runUpdate(channel, timestamp, text string, opts *updateOptions, c *client.C
 	// Unescape shell-escaped characters (e.g., \! from zsh)
 	text = unescapeShellChars(text)
 
+	if err := validateMessageLength(text); err != nil {
+		return err
+	}
+
 	if c == nil {
 		var err error
 		c, err = client.New()


### PR DESCRIPTION
## Summary
- Adds pre-send validation for message text length against Slack's 40,000 character hard limit
- Returns an actionable error with alternatives (`--file`, `canvas create`, manual chunking) instead of letting Slack silently truncate
- Applies to both `messages send` and `messages update`; skipped for file uploads
- Trues up CHANGELOG.md: removes `[Unreleased]`, creates `[3.2.0]` and `[3.1.35]` sections
- Adds Message Length Limits entry to README Known Limitations

Closes #139

## Test plan
- [x] `TestValidateMessageLength` — under/at/over limit boundary tests
- [x] `TestRunSend_MessageTooLong` — send rejects oversized text
- [x] `TestRunUpdate_MessageTooLong` — update rejects oversized text
- [x] `TestRunSend_FileUpload_LongTextAllowed` — file uploads bypass length check
- [x] Manual: `python3 -c "print('x' * 50000)" | ./bin/slck messages send C123 -` → error with helpful message
- [x] `make build && make test && make lint` all pass