### PR TITLE
fix(messages): render file attachments and rich_text blocks in text output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,12 @@
 - `edited` metadata field on messages with `[edited]` text indicator (#136)
 - Idempotent handling for react, unreact, archive, unarchive, and invite commands (#130)
 - Pre-send message length validation — errors with helpful alternatives when text exceeds Slack's 40,000 character limit (#139)
+- `messages thread` and `messages history` now surface file attachments in text output as `[file] <name> (<type>, <size>) — slck files download <id>` hints, giving readers a valid download command inline (#141)
+- `messages thread` and `messages history` now render Slack rich-text blocks (previously dropped), so messages pasted as tables, lists, or formatted content are visible in the default text output (#141)
 
 ### Fixed
 - `messages thread` text output no longer truncates at 80 characters (#134)
+- `messages thread` / `messages history` no longer silently drop file attachments or rich-text block content (#141)
 
 ## [3.1.35]
 

--- a/README.md
+++ b/README.md
@@ -222,6 +222,89 @@ This means environment variables always override stored credentials, allowing au
      socket_mode_enabled: false
    ```
    </details>
+
+   <details>
+   <summary><strong>Extended manifest</strong> — every read scope slck can use, plus all writes (DMs, group DMs, file uploads, canvas CRUD, etc.)</summary>
+
+   Use this if you want maximum capability out of the box — reading DMs and group DMs, uploading file attachments to any channel/DM/group-DM, creating/editing/deleting canvases, resolving `@subteam` mentions, extended user profile data, etc. Every scope here is either needed by an existing slck command or unlocks a capability that commonly extends one (e.g. `im:history` so `slck messages thread` works on DMs, `files:write` for `slck messages send --file`, `canvases:write` for `slck canvas create`).
+
+   ```json
+   {
+     "display_information": {
+       "name": "Slack Chat API"
+     },
+     "features": {
+       "bot_user": {
+         "display_name": "Slack Chat API",
+         "always_online": false
+       }
+     },
+     "oauth_config": {
+       "scopes": {
+         "bot": [
+           "app_mentions:read",
+           "bookmarks:read",
+           "calls:read",
+           "canvases:read",
+           "canvases:write",
+           "channels:history",
+           "channels:manage",
+           "channels:read",
+           "chat:write",
+           "chat:write.public",
+           "dnd:read",
+           "emoji:read",
+           "files:read",
+           "files:write",
+           "groups:history",
+           "groups:read",
+           "groups:write",
+           "im:history",
+           "im:read",
+           "im:write",
+           "links:read",
+           "lists:read",
+           "metadata.message:read",
+           "mpim:history",
+           "mpim:read",
+           "mpim:write",
+           "pins:read",
+           "reactions:read",
+           "reactions:write",
+           "reminders:read",
+           "remote_files:read",
+           "search:read.files",
+           "search:read.mpim",
+           "search:read.public",
+           "search:read.users",
+           "team:read",
+           "usergroups:read",
+           "users.profile:read",
+           "users:read"
+         ],
+         "user": [
+           "search:read",
+           "search:read.files",
+           "search:read.im",
+           "search:read.mpim",
+           "search:read.private",
+           "search:read.public",
+           "search:read.users"
+         ]
+       },
+       "pkce_enabled": false
+     },
+     "settings": {
+       "org_deploy_enabled": false,
+       "socket_mode_enabled": false,
+       "token_rotation_enabled": false,
+       "is_mcp_enabled": false
+     }
+   }
+   ```
+
+   **Upgrading an existing install?** Paste the full manifest above into your app's **Features → App Manifest** tab (replacing the previous manifest), click **Save Changes**, then click **Install App → Reinstall to Workspace** to grant the new scopes. Copy the fresh `xoxb-…` token and run `slck config set-token`.
+   </details>
 4. Click **Create** → **Install to Workspace** → **Allow**
 5. Copy the **Bot User OAuth Token** (starts with `xoxb-`)
 6. Run:
@@ -280,6 +363,22 @@ The manifest above includes these scopes:
 | `team:read` | Get workspace info |
 | `users:read` | List users, get user info |
 | `search:read` | Search messages and files (user token only) |
+
+The **extended manifest** (see the collapsible section above) adds these capabilities on top of the default:
+
+| Scope | Unlocks |
+|-------|---------|
+| `im:history` / `im:read` / `im:write` | Read messages in DMs, list DMs, open new DMs to post to |
+| `mpim:history` / `mpim:read` / `mpim:write` | Same for multi-person DMs (group DMs) |
+| `files:write` | Upload files — `slck messages send --file` in any channel/DM/group-DM |
+| `canvases:write` | Create, edit, delete canvases — `slck canvas create/edit/delete` |
+| `groups:write` | Create/archive private channels |
+| `chat:write.public` | Post to public channels the bot isn't a member of |
+| `users.profile:read` | Extended user profile (status, timezone, custom fields) |
+| `usergroups:read` | Resolve `@subteam` / user-group mentions |
+| `app_mentions:read` | Receive @-mention events (needed for event subscriptions) |
+| `reactions:read` | List reactions on a message |
+| Other `*:read` scopes (`bookmarks`, `pins`, `reminders`, `links`, `lists`, `calls`, `dnd`, `metadata.message`, `remote_files`) | Read-only access to those domains; mostly forward-compat for commands that may use them |
 
 ### Token Types
 

--- a/internal/client/blocks.go
+++ b/internal/client/blocks.go
@@ -1,0 +1,242 @@
+package client
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+)
+
+// Block is a top-level Slack Block Kit block. Only rich_text is rendered
+// today; other types (section, image, context, etc.) are preserved in the
+// JSON representation but yield empty output from RenderBlocks, letting
+// callers fall back to the message's m.Text plain-text fallback.
+type Block struct {
+	Type     string            `json:"type"`
+	BlockID  string            `json:"block_id,omitempty"`
+	Elements []json.RawMessage `json:"elements,omitempty"`
+}
+
+// RichTextElement is one element inside a rich_text block. The zero value
+// plus the non-nil Elements signal a container (rich_text_section,
+// rich_text_list, rich_text_preformatted, rich_text_quote). Otherwise the
+// element is an inline primitive (text, link, user, channel, emoji,
+// broadcast, usergroup, date).
+type RichTextElement struct {
+	Type     string            `json:"type"`
+	Elements []json.RawMessage `json:"elements,omitempty"`
+
+	// rich_text_list fields (only populated when Type == "rich_text_list")
+	ListStyle string `json:"-"` // "bullet" | "ordered" — populated from polymorphic "style"
+	Indent    int    `json:"indent,omitempty"`
+	Offset    int    `json:"offset,omitempty"`
+	Border    int    `json:"border,omitempty"`
+
+	// inline element fields
+	Text        string `json:"text,omitempty"`
+	URL         string `json:"url,omitempty"`
+	UserID      string `json:"user_id,omitempty"`
+	ChannelID   string `json:"channel_id,omitempty"`
+	Name        string `json:"name,omitempty"`      // emoji name
+	Range       string `json:"range,omitempty"`     // broadcast: here|channel|everyone
+	Timestamp   int64  `json:"timestamp,omitempty"` // date element (unix seconds)
+	Format      string `json:"format,omitempty"`    // date format (not interpreted — Fallback/RFC3339 used instead)
+	Fallback    string `json:"fallback,omitempty"`  // date fallback text
+	UsergroupID string `json:"usergroup_id,omitempty"`
+
+	TextStyle *RichTextStyle `json:"-"` // populated from polymorphic "style"
+}
+
+// RichTextStyle captures inline text formatting flags on a "text" element.
+type RichTextStyle struct {
+	Bold   bool `json:"bold,omitempty"`
+	Italic bool `json:"italic,omitempty"`
+	Code   bool `json:"code,omitempty"`
+	Strike bool `json:"strike,omitempty"`
+}
+
+// UnmarshalJSON handles the "style" field's polymorphism: rich_text_list
+// uses a string ("bullet"|"ordered"), inline text uses an object of
+// boolean flags. Everything else is unmarshaled via the standard rules
+// after stripping "style" out to avoid the default unmarshaler choking.
+func (e *RichTextElement) UnmarshalJSON(data []byte) error {
+	type alias RichTextElement
+	aux := struct {
+		*alias
+		Style json.RawMessage `json:"style,omitempty"`
+	}{alias: (*alias)(e)}
+	if err := json.Unmarshal(data, &aux); err != nil {
+		return err
+	}
+	if len(aux.Style) == 0 {
+		return nil
+	}
+	trimmed := strings.TrimLeft(string(aux.Style), " \t\n\r")
+	if strings.HasPrefix(trimmed, `"`) {
+		var s string
+		if err := json.Unmarshal(aux.Style, &s); err != nil {
+			return err
+		}
+		e.ListStyle = s
+		return nil
+	}
+	if strings.HasPrefix(trimmed, "{") {
+		var ts RichTextStyle
+		if err := json.Unmarshal(aux.Style, &ts); err != nil {
+			return err
+		}
+		e.TextStyle = &ts
+	}
+	return nil
+}
+
+// MarshalJSON round-trips the polymorphic style field so --output json
+// preserves whichever variant was on the wire.
+func (e RichTextElement) MarshalJSON() ([]byte, error) {
+	type alias RichTextElement
+	aux := struct {
+		alias
+		Style interface{} `json:"style,omitempty"`
+	}{alias: alias(e)}
+	switch {
+	case e.ListStyle != "":
+		aux.Style = e.ListStyle
+	case e.TextStyle != nil:
+		aux.Style = e.TextStyle
+	}
+	return json.Marshal(aux)
+}
+
+// RenderBlocks walks top-level blocks and returns plain text suitable for
+// slck's text output. Returns "" if blocks is empty or no block yields
+// output — callers can use that signal to fall back to m.Text. Safe to
+// call with a nil resolver.
+func RenderBlocks(blocks []Block, resolver *UserResolver) string {
+	if len(blocks) == 0 {
+		return ""
+	}
+	var out strings.Builder
+	for _, b := range blocks {
+		if b.Type != "rich_text" {
+			// Non-rich_text blocks (section, image, context, etc.) are
+			// dropped so the caller falls back to m.Text, which Slack
+			// populates as a plain-text equivalent for these cases.
+			continue
+		}
+		out.WriteString(renderRichText(b.Elements, resolver, 0))
+	}
+	return strings.TrimRight(out.String(), "\n")
+}
+
+// renderRichText walks the sub-elements of a rich_text block.
+func renderRichText(raws []json.RawMessage, resolver *UserResolver, baseIndent int) string {
+	var out strings.Builder
+	for _, raw := range raws {
+		var el RichTextElement
+		if err := json.Unmarshal(raw, &el); err != nil {
+			continue
+		}
+		switch el.Type {
+		case "rich_text_section":
+			out.WriteString(renderInline(el.Elements, resolver))
+			out.WriteString("\n")
+		case "rich_text_preformatted":
+			out.WriteString("```\n")
+			out.WriteString(renderInline(el.Elements, resolver))
+			out.WriteString("\n```\n")
+		case "rich_text_quote":
+			body := renderInline(el.Elements, resolver)
+			for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
+				out.WriteString("> ")
+				out.WriteString(line)
+				out.WriteString("\n")
+			}
+		case "rich_text_list":
+			indent := strings.Repeat("  ", baseIndent+el.Indent)
+			start := el.Offset
+			for i, itemRaw := range el.Elements {
+				var item RichTextElement
+				if err := json.Unmarshal(itemRaw, &item); err != nil {
+					continue
+				}
+				// List items are rich_text_section elements
+				body := renderInline(item.Elements, resolver)
+				out.WriteString(indent)
+				if el.ListStyle == "ordered" {
+					fmt.Fprintf(&out, "%d. ", start+i+1)
+				} else {
+					out.WriteString("- ")
+				}
+				out.WriteString(body)
+				out.WriteString("\n")
+			}
+		default:
+			// Unknown sub-block type — drop silently.
+		}
+	}
+	return out.String()
+}
+
+// renderInline walks the inline elements of a rich_text_section.
+func renderInline(raws []json.RawMessage, resolver *UserResolver) string {
+	var out strings.Builder
+	for _, raw := range raws {
+		var el RichTextElement
+		if err := json.Unmarshal(raw, &el); err != nil {
+			continue
+		}
+		switch el.Type {
+		case "text":
+			out.WriteString(applyTextStyle(el.Text, el.TextStyle))
+		case "link":
+			if el.Text != "" {
+				fmt.Fprintf(&out, "[%s](%s)", el.Text, el.URL)
+			} else {
+				fmt.Fprintf(&out, "<%s>", el.URL)
+			}
+		case "user":
+			name := resolver.Resolve(el.UserID)
+			fmt.Fprintf(&out, "@%s", name)
+		case "channel":
+			fmt.Fprintf(&out, "<#%s>", el.ChannelID)
+		case "emoji":
+			fmt.Fprintf(&out, ":%s:", el.Name)
+		case "broadcast":
+			fmt.Fprintf(&out, "@%s", el.Range)
+		case "usergroup":
+			fmt.Fprintf(&out, "<!subteam^%s>", el.UsergroupID)
+		case "date":
+			if el.Fallback != "" {
+				out.WriteString(el.Fallback)
+			} else if el.Timestamp > 0 {
+				out.WriteString(time.Unix(el.Timestamp, 0).UTC().Format(time.RFC3339))
+			}
+			// Slack's date-format token language ({date_num}, {date}, etc.)
+			// is intentionally not interpreted — Format is read for JSON
+			// round-tripping but ignored during rendering.
+		default:
+			// Unknown inline element — drop silently so fall-back to
+			// m.Text can win if every element is unknown.
+		}
+	}
+	return out.String()
+}
+
+func applyTextStyle(s string, style *RichTextStyle) string {
+	if style == nil || s == "" {
+		return s
+	}
+	if style.Code {
+		s = "`" + s + "`"
+	}
+	if style.Bold {
+		s = "**" + s + "**"
+	}
+	if style.Italic {
+		s = "*" + s + "*"
+	}
+	if style.Strike {
+		s = "~~" + s + "~~"
+	}
+	return s
+}

--- a/internal/client/blocks.go
+++ b/internal/client/blocks.go
@@ -138,11 +138,21 @@ func renderRichText(raws []json.RawMessage, resolver *UserResolver, baseIndent i
 		}
 		switch el.Type {
 		case "rich_text_section":
-			out.WriteString(renderInline(el.Elements, resolver))
+			inline := renderInline(el.Elements, resolver)
+			if inline == "" {
+				// Skip empty sections (all inline elements unknown) so they
+				// don't emit blank indented lines in thread's multi-line view.
+				continue
+			}
+			out.WriteString(inline)
 			out.WriteString("\n")
 		case "rich_text_preformatted":
+			// Trim trailing newlines on the inner content so we emit
+			// "```\n<body>\n```" even if the inline text carries its own
+			// trailing "\n" (valid Slack payload).
+			inline := strings.TrimRight(renderInline(el.Elements, resolver), "\n")
 			out.WriteString("```\n")
-			out.WriteString(renderInline(el.Elements, resolver))
+			out.WriteString(inline)
 			out.WriteString("\n```\n")
 		case "rich_text_quote":
 			body := renderInline(el.Elements, resolver)

--- a/internal/client/blocks.go
+++ b/internal/client/blocks.go
@@ -9,12 +9,39 @@ import (
 
 // Block is a top-level Slack Block Kit block. Only rich_text is rendered
 // today; other types (section, image, context, etc.) are preserved in the
-// JSON representation but yield empty output from RenderBlocks, letting
-// callers fall back to the message's m.Text plain-text fallback.
+// JSON representation via raw-bytes round-tripping, and yield empty output
+// from RenderBlocks so callers fall back to the message's m.Text
+// plain-text fallback.
 type Block struct {
 	Type     string            `json:"type"`
 	BlockID  string            `json:"block_id,omitempty"`
 	Elements []json.RawMessage `json:"elements,omitempty"`
+
+	// raw holds the verbatim JSON bytes captured during unmarshal so that
+	// non-rich_text blocks (section.text, image.image_url, header.text,
+	// etc.) round-trip through --output json without losing fields the
+	// typed struct doesn't model.
+	raw json.RawMessage
+}
+
+// UnmarshalJSON captures the raw bytes alongside the typed fields so that
+// non-rich_text blocks can be re-emitted without loss.
+func (b *Block) UnmarshalJSON(data []byte) error {
+	b.raw = append(b.raw[:0], data...)
+	type alias Block
+	return json.Unmarshal(data, (*alias)(b))
+}
+
+// MarshalJSON emits the original raw bytes for non-rich_text blocks (which
+// carry type-specific fields the struct does not model) and the typed form
+// for rich_text blocks (which preserves polymorphic-style re-emission
+// through RichTextElement.MarshalJSON).
+func (b Block) MarshalJSON() ([]byte, error) {
+	if b.Type != "rich_text" && len(b.raw) > 0 {
+		return b.raw, nil
+	}
+	type alias Block
+	return json.Marshal(alias(b))
 }
 
 // RichTextElement is one element inside a rich_text block. The zero value
@@ -147,15 +174,23 @@ func renderRichText(raws []json.RawMessage, resolver *UserResolver, baseIndent i
 			out.WriteString(inline)
 			out.WriteString("\n")
 		case "rich_text_preformatted":
-			// Trim trailing newlines on the inner content so we emit
-			// "```\n<body>\n```" even if the inline text carries its own
-			// trailing "\n" (valid Slack payload).
-			inline := strings.TrimRight(renderInline(el.Elements, resolver), "\n")
+			// Preformatted blocks strip inline styles — markdown markers
+			// inside a fenced code block would render as literal text in
+			// downstream consumers.
+			inline := strings.TrimRight(renderInlineRaw(el.Elements, resolver), "\n")
+			if inline == "" {
+				continue
+			}
 			out.WriteString("```\n")
 			out.WriteString(inline)
 			out.WriteString("\n```\n")
 		case "rich_text_quote":
 			body := renderInline(el.Elements, resolver)
+			if body == "" {
+				// Skip quotes with no renderable content so we don't emit
+				// a phantom "> " line from the Split(\"\", \"\\n\") edge.
+				continue
+			}
 			for _, line := range strings.Split(strings.TrimRight(body, "\n"), "\n") {
 				out.WriteString("> ")
 				out.WriteString(line)
@@ -164,21 +199,28 @@ func renderRichText(raws []json.RawMessage, resolver *UserResolver, baseIndent i
 		case "rich_text_list":
 			indent := strings.Repeat("  ", baseIndent+el.Indent)
 			start := el.Offset
-			for i, itemRaw := range el.Elements {
+			// Track rendered items separately from the loop index so that
+			// skipped items (malformed JSON or empty body) don't leave
+			// numbering gaps in ordered lists.
+			rendered := 0
+			for _, itemRaw := range el.Elements {
 				var item RichTextElement
 				if err := json.Unmarshal(itemRaw, &item); err != nil {
 					continue
 				}
-				// List items are rich_text_section elements
 				body := renderInline(item.Elements, resolver)
+				if body == "" {
+					continue
+				}
 				out.WriteString(indent)
 				if el.ListStyle == "ordered" {
-					fmt.Fprintf(&out, "%d. ", start+i+1)
+					fmt.Fprintf(&out, "%d. ", start+rendered+1)
 				} else {
 					out.WriteString("- ")
 				}
 				out.WriteString(body)
 				out.WriteString("\n")
+				rendered++
 			}
 		default:
 			// Unknown sub-block type — drop silently.
@@ -187,8 +229,19 @@ func renderRichText(raws []json.RawMessage, resolver *UserResolver, baseIndent i
 	return out.String()
 }
 
+// renderInlineRaw is like renderInline but strips inline text styles, for
+// use inside rich_text_preformatted where markdown markers would render as
+// literal text rather than formatting.
+func renderInlineRaw(raws []json.RawMessage, resolver *UserResolver) string {
+	return renderInlineWithStyle(raws, resolver, false)
+}
+
 // renderInline walks the inline elements of a rich_text_section.
 func renderInline(raws []json.RawMessage, resolver *UserResolver) string {
+	return renderInlineWithStyle(raws, resolver, true)
+}
+
+func renderInlineWithStyle(raws []json.RawMessage, resolver *UserResolver, applyStyles bool) string {
 	var out strings.Builder
 	for _, raw := range raws {
 		var el RichTextElement
@@ -197,7 +250,11 @@ func renderInline(raws []json.RawMessage, resolver *UserResolver) string {
 		}
 		switch el.Type {
 		case "text":
-			out.WriteString(applyTextStyle(el.Text, el.TextStyle))
+			if applyStyles {
+				out.WriteString(applyTextStyle(el.Text, el.TextStyle))
+			} else {
+				out.WriteString(el.Text)
+			}
 		case "link":
 			if el.Text != "" {
 				fmt.Fprintf(&out, "[%s](%s)", el.Text, el.URL)

--- a/internal/client/blocks.go
+++ b/internal/client/blocks.go
@@ -33,9 +33,12 @@ func (b *Block) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON emits the original raw bytes for non-rich_text blocks (which
-// carry type-specific fields the struct does not model) and the typed form
-// for rich_text blocks (which preserves polymorphic-style re-emission
-// through RichTextElement.MarshalJSON).
+// carry type-specific fields the struct does not model). For rich_text
+// blocks it re-emits via the typed alias; Elements is []json.RawMessage
+// so each element's original bytes pass through unchanged, which is what
+// preserves the polymorphic "style" field on rich_text_list items and
+// inline text runs. RichTextElement.UnmarshalJSON/MarshalJSON are only
+// invoked when a caller explicitly unmarshals an individual element.
 func (b Block) MarshalJSON() ([]byte, error) {
 	if b.Type != "rich_text" && len(b.raw) > 0 {
 		return b.raw, nil

--- a/internal/client/blocks_test.go
+++ b/internal/client/blocks_test.go
@@ -433,6 +433,135 @@ func TestRenderBlocks_EmptySectionDoesNotEmitBlankLine(t *testing.T) {
 	assert.Equal(t, "visible", RenderBlocks(blocks, nil))
 }
 
+func TestRenderBlocks_QuoteWithEmptyBodySkipped(t *testing.T) {
+	// rich_text_quote whose every inline element is unknown should not
+	// emit a phantom "> " line — strings.Split("", "\n") yields [""] which
+	// would otherwise run the loop once.
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_quote", "elements": [
+				{"type": "future_inline", "text": "dropped"}
+			]},
+			{"type": "rich_text_section", "elements": [
+				{"type": "text", "text": "after"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Equal(t, "after", got)
+	assert.NotContains(t, got, "> ")
+}
+
+func TestRenderBlocks_PreformattedWithEmptyBodySkipped(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_preformatted", "elements": [
+				{"type": "future_inline", "text": "dropped"}
+			]},
+			{"type": "rich_text_section", "elements": [
+				{"type": "text", "text": "after"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Equal(t, "after", got)
+	assert.NotContains(t, got, "```")
+}
+
+func TestRenderBlocks_ListItemWithEmptyBodySkipped(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_list", "style": "bullet", "elements": [
+				{"type": "rich_text_section", "elements": [
+					{"type": "future_inline", "text": "dropped"}
+				]},
+				{"type": "rich_text_section", "elements": [
+					{"type": "text", "text": "good"}
+				]}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	// No phantom "- " line from the first item.
+	lines := strings.Split(got, "\n")
+	bulletLines := 0
+	for _, l := range lines {
+		if strings.HasPrefix(l, "- ") {
+			bulletLines++
+		}
+	}
+	assert.Equal(t, 1, bulletLines, "expected exactly one bullet line, got %q", got)
+}
+
+func TestRenderBlocks_OrderedListSkipPreservesNumbering(t *testing.T) {
+	// Ordered list with a malformed middle item: remaining items should
+	// number 1, 2 — not 1, 3 with a gap where the bad item was.
+	blocks := []Block{{
+		Type: "rich_text",
+		Elements: []json.RawMessage{
+			json.RawMessage(`{
+				"type": "rich_text_list",
+				"style": "ordered",
+				"elements": [
+					{"type": "rich_text_section", "elements": [{"type":"text","text":"first"}]},
+					"not-an-object",
+					{"type": "rich_text_section", "elements": [{"type":"text","text":"second"}]}
+				]
+			}`),
+		},
+	}}
+	got := RenderBlocks(blocks, nil)
+	assert.Contains(t, got, "1. first")
+	assert.Contains(t, got, "2. second", "expected contiguous numbering, got %q", got)
+	assert.NotContains(t, got, "3. ")
+}
+
+func TestRenderBlocks_PreformattedStripsInlineStyles(t *testing.T) {
+	// A bold text element inside a preformatted block should NOT emit
+	// markdown markers inside the fence — they'd render as literal text.
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_preformatted", "elements": [
+				{"type": "text", "text": "shouty", "style": {"bold": true}}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Equal(t, "```\nshouty\n```", got)
+	assert.NotContains(t, got, "**")
+}
+
+func TestBlock_JSONFidelityForNonRichTextBlocks(t *testing.T) {
+	// A section block carries "text" in a field the typed Block struct
+	// doesn't model. Round-tripping through unmarshal → marshal must
+	// preserve it verbatim so --output json consumers see the content.
+	raw := []byte(`{"type":"section","block_id":"B1","text":{"type":"mrkdwn","text":"hello *world*"}}`)
+	var b Block
+	require.NoError(t, json.Unmarshal(raw, &b))
+	assert.Equal(t, "section", b.Type)
+
+	out, err := json.Marshal(b)
+	require.NoError(t, err)
+	// The "text" field must survive even though Block doesn't model it.
+	assert.Contains(t, string(out), `"text":{"type":"mrkdwn","text":"hello *world*"}`)
+}
+
+func TestBlock_JSONFidelityForRichTextUsesTypedMarshal(t *testing.T) {
+	// rich_text blocks go through the typed marshal so
+	// RichTextElement.MarshalJSON preserves polymorphic style. Verify
+	// that path still works alongside the new raw-bytes path.
+	raw := []byte(`{"type":"rich_text","elements":[{"type":"rich_text_list","style":"ordered","elements":[]}]}`)
+	var b Block
+	require.NoError(t, json.Unmarshal(raw, &b))
+	out, err := json.Marshal(b)
+	require.NoError(t, err)
+	assert.Contains(t, string(out), `"style":"ordered"`)
+}
+
 func TestRenderBlocks_UnknownBlockAlongsideKnown(t *testing.T) {
 	// A slice with an unknown top-level block followed by a rich_text
 	// block must drop the unknown and still render the known content.

--- a/internal/client/blocks_test.go
+++ b/internal/client/blocks_test.go
@@ -1,0 +1,267 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRenderBlocks_NilAndEmpty(t *testing.T) {
+	assert.Equal(t, "", RenderBlocks(nil, nil))
+	assert.Equal(t, "", RenderBlocks([]Block{}, nil))
+}
+
+func TestRenderBlocks_NilResolverDoesNotPanic(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_section", "elements": [
+				{"type": "text", "text": "hi "},
+				{"type": "user", "user_id": "U123"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	// Resolver nil → user mentions fall back to raw ID prefixed with @.
+	assert.Equal(t, "hi @U123", got)
+}
+
+func TestRenderBlocks_RichTextSection(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_section", "elements": [
+				{"type": "text", "text": "hello "},
+				{"type": "text", "text": "world", "style": {"bold": true}}
+			]}
+		]
+	}]`)
+	assert.Equal(t, "hello **world**", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_TextStyleCombinations(t *testing.T) {
+	tests := []struct {
+		name, rawStyle, expected string
+	}{
+		{"bold", `{"bold":true}`, "**x**"},
+		{"italic", `{"italic":true}`, "*x*"},
+		{"code", `{"code":true}`, "`x`"},
+		{"strike", `{"strike":true}`, "~~x~~"},
+		{"bold_italic", `{"bold":true,"italic":true}`, "***x***"},
+		{"code_bold", `{"code":true,"bold":true}`, "**`x`**"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			raw := `[{"type":"rich_text","elements":[{"type":"rich_text_section","elements":[{"type":"text","text":"x","style":` + tt.rawStyle + `}]}]}]`
+			blocks := mustBlocks(t, raw)
+			assert.Equal(t, tt.expected, RenderBlocks(blocks, nil))
+		})
+	}
+}
+
+func TestRenderBlocks_BulletList(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_list", "style": "bullet", "elements": [
+				{"type": "rich_text_section", "elements": [{"type": "text", "text": "first"}]},
+				{"type": "rich_text_section", "elements": [{"type": "text", "text": "second"}]}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Contains(t, got, "- first")
+	assert.Contains(t, got, "- second")
+}
+
+func TestRenderBlocks_OrderedListHonorsOffset(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_list", "style": "ordered", "offset": 4, "elements": [
+				{"type": "rich_text_section", "elements": [{"type": "text", "text": "apple"}]},
+				{"type": "rich_text_section", "elements": [{"type": "text", "text": "banana"}]}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Contains(t, got, "5. apple")
+	assert.Contains(t, got, "6. banana")
+}
+
+func TestRenderBlocks_NestedListIndent(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_list", "style": "bullet", "indent": 1, "elements": [
+				{"type": "rich_text_section", "elements": [{"type": "text", "text": "child"}]}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Contains(t, got, "  - child", "expected two-space indent before bullet")
+}
+
+func TestRenderBlocks_Preformatted(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_preformatted", "elements": [
+				{"type": "text", "text": "code block body"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Contains(t, got, "```")
+	assert.Contains(t, got, "code block body")
+}
+
+func TestRenderBlocks_Quote(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_quote", "elements": [
+				{"type": "text", "text": "line one\nline two"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	for _, want := range []string{"> line one", "> line two"} {
+		assert.Contains(t, got, want)
+	}
+}
+
+func TestRenderBlocks_InlineElementTypes(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_section", "elements": [
+				{"type": "text", "text": "pre "},
+				{"type": "link", "url": "https://example.com", "text": "site"},
+				{"type": "text", "text": " "},
+				{"type": "link", "url": "https://bare.example.com"},
+				{"type": "text", "text": " "},
+				{"type": "channel", "channel_id": "C123"},
+				{"type": "text", "text": " "},
+				{"type": "emoji", "name": "wave"},
+				{"type": "text", "text": " "},
+				{"type": "broadcast", "range": "here"},
+				{"type": "text", "text": " "},
+				{"type": "usergroup", "usergroup_id": "S01"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Contains(t, got, "[site](https://example.com)")
+	assert.Contains(t, got, "<https://bare.example.com>")
+	assert.Contains(t, got, "<#C123>")
+	assert.Contains(t, got, ":wave:")
+	assert.Contains(t, got, "@here")
+	assert.Contains(t, got, "<!subteam^S01>")
+}
+
+func TestRenderBlocks_DateUsesFallbackOrRFC3339(t *testing.T) {
+	t.Run("fallback wins when present", func(t *testing.T) {
+		blocks := mustBlocks(t, `[{
+			"type": "rich_text",
+			"elements": [
+				{"type": "rich_text_section", "elements": [
+					{"type": "date", "timestamp": 1700000000, "format": "{date_num}", "fallback": "Nov 14, 2023"}
+				]}
+			]
+		}]`)
+		assert.Equal(t, "Nov 14, 2023", RenderBlocks(blocks, nil))
+	})
+
+	t.Run("RFC3339 when no fallback", func(t *testing.T) {
+		blocks := mustBlocks(t, `[{
+			"type": "rich_text",
+			"elements": [
+				{"type": "rich_text_section", "elements": [
+					{"type": "date", "timestamp": 1700000000, "format": "{date_num}"}
+				]}
+			]
+		}]`)
+		got := RenderBlocks(blocks, nil)
+		// RFC3339 of 1700000000 UTC
+		assert.Contains(t, got, "2023-11-14T")
+	})
+}
+
+func TestRenderBlocks_UnknownBlockTypeDropped(t *testing.T) {
+	// A non-rich_text block should be silently dropped so callers can
+	// fall back to m.Text, which Slack populates for such messages.
+	blocks := mustBlocks(t, `[{"type":"section","block_id":"B1"}]`)
+	assert.Equal(t, "", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_UnknownSubBlockDropped(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [{"type": "rich_text_future_thing", "elements": []}]
+	}]`)
+	assert.Equal(t, "", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_UnknownInlineElementDropped(t *testing.T) {
+	// Unknown inline elements yield empty output — if every element is
+	// unknown, overall render is empty, letting fallback-to-text win.
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [{"type": "rich_text_section", "elements": [
+			{"type": "unknown_inline_type", "text": "ignored"}
+		]}]
+	}]`)
+	assert.Equal(t, "", RenderBlocks(blocks, nil))
+}
+
+func TestRichTextElement_StylePolymorphism(t *testing.T) {
+	t.Run("list style is a string", func(t *testing.T) {
+		var el RichTextElement
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"rich_text_list","style":"ordered"}`), &el))
+		assert.Equal(t, "ordered", el.ListStyle)
+		assert.Nil(t, el.TextStyle)
+	})
+
+	t.Run("text style is an object", func(t *testing.T) {
+		var el RichTextElement
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"text","text":"x","style":{"bold":true,"italic":true}}`), &el))
+		assert.Equal(t, "", el.ListStyle)
+		require.NotNil(t, el.TextStyle)
+		assert.True(t, el.TextStyle.Bold)
+		assert.True(t, el.TextStyle.Italic)
+	})
+
+	t.Run("missing style is fine", func(t *testing.T) {
+		var el RichTextElement
+		require.NoError(t, json.Unmarshal([]byte(`{"type":"text","text":"x"}`), &el))
+		assert.Equal(t, "", el.ListStyle)
+		assert.Nil(t, el.TextStyle)
+	})
+}
+
+func TestRenderBlocks_MultilineSectionsSeparatedByNewlines(t *testing.T) {
+	// Two sections → two rendered lines, joined by newline (but trailing
+	// newline on the final output is trimmed).
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_section", "elements": [{"type": "text", "text": "line1"}]},
+			{"type": "rich_text_section", "elements": [{"type": "text", "text": "line2"}]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Equal(t, "line1\nline2", got)
+	assert.False(t, strings.HasSuffix(got, "\n"), "trailing newline should be trimmed")
+}
+
+// mustBlocks unmarshals a JSON array into []Block or fails the test.
+func mustBlocks(t *testing.T, raw string) []Block {
+	t.Helper()
+	var blocks []Block
+	require.NoError(t, json.Unmarshal([]byte(raw), &blocks))
+	return blocks
+}

--- a/internal/client/blocks_test.go
+++ b/internal/client/blocks_test.go
@@ -395,6 +395,44 @@ func TestRenderBlocks_DateZeroTimestampNoFallback(t *testing.T) {
 	assert.Equal(t, "", RenderBlocks(blocks, nil))
 }
 
+func TestRenderBlocks_PreformattedInnerTrailingNewlineTrimmed(t *testing.T) {
+	// If the inline content inside a preformatted block carries its own
+	// trailing newline, we must not emit a blank line before the closing
+	// fence.
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_preformatted", "elements": [
+				{"type": "text", "text": "code\n"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Equal(t, "```\ncode\n```", got)
+	assert.NotContains(t, got, "\n\n```", "expected no blank line before closing fence")
+}
+
+func TestRenderBlocks_EmptySectionDoesNotEmitBlankLine(t *testing.T) {
+	// A rich_text_section whose every inline element is unknown should
+	// not emit a blank line — otherwise thread view's indentContinuation
+	// produces a visible "\n\t" artifact after the "[ts] user:" header.
+	// Here we pair an empty (unknown-only) section with a known one to
+	// prove the known one renders cleanly without a leading blank.
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_section", "elements": [
+				{"type": "future_inline", "text": "dropped"}
+			]},
+			{"type": "rich_text_section", "elements": [
+				{"type": "text", "text": "visible"}
+			]}
+		]
+	}]`)
+	// Before the fix: "\nvisible". After: "visible".
+	assert.Equal(t, "visible", RenderBlocks(blocks, nil))
+}
+
 func TestRenderBlocks_UnknownBlockAlongsideKnown(t *testing.T) {
 	// A slice with an unknown top-level block followed by a rich_text
 	// block must drop the unknown and still render the known content.

--- a/internal/client/blocks_test.go
+++ b/internal/client/blocks_test.go
@@ -258,6 +258,157 @@ func TestRenderBlocks_MultilineSectionsSeparatedByNewlines(t *testing.T) {
 	assert.False(t, strings.HasSuffix(got, "\n"), "trailing newline should be trimmed")
 }
 
+func TestRichTextElement_MarshalJSONRoundTrip(t *testing.T) {
+	t.Run("list style string survives round trip", func(t *testing.T) {
+		raw := []byte(`{"type":"rich_text_list","style":"ordered","offset":3}`)
+		var el RichTextElement
+		require.NoError(t, json.Unmarshal(raw, &el))
+
+		out, err := json.Marshal(el)
+		require.NoError(t, err)
+
+		// Re-unmarshal to confirm style is preserved via both JSON and Go fields.
+		var roundTrip RichTextElement
+		require.NoError(t, json.Unmarshal(out, &roundTrip))
+		assert.Equal(t, "ordered", roundTrip.ListStyle)
+		assert.Equal(t, 3, roundTrip.Offset)
+		assert.Nil(t, roundTrip.TextStyle)
+
+		// And that the emitted JSON contains "style":"ordered" literally.
+		assert.Contains(t, string(out), `"style":"ordered"`)
+	})
+
+	t.Run("text style object survives round trip", func(t *testing.T) {
+		raw := []byte(`{"type":"text","text":"x","style":{"bold":true,"italic":true}}`)
+		var el RichTextElement
+		require.NoError(t, json.Unmarshal(raw, &el))
+
+		out, err := json.Marshal(el)
+		require.NoError(t, err)
+
+		var roundTrip RichTextElement
+		require.NoError(t, json.Unmarshal(out, &roundTrip))
+		require.NotNil(t, roundTrip.TextStyle)
+		assert.True(t, roundTrip.TextStyle.Bold)
+		assert.True(t, roundTrip.TextStyle.Italic)
+		assert.Equal(t, "", roundTrip.ListStyle)
+
+		// Style must be emitted as an object, not a string.
+		assert.Contains(t, string(out), `"bold":true`)
+	})
+
+	t.Run("absent style is not emitted", func(t *testing.T) {
+		el := RichTextElement{Type: "text", Text: "x"}
+		out, err := json.Marshal(el)
+		require.NoError(t, err)
+		assert.NotContains(t, string(out), `"style"`)
+	})
+}
+
+func TestRenderBlocks_PreformattedMultiline(t *testing.T) {
+	// Multiline body inside a preformatted block: ensure the renderer
+	// wraps the body in fences without producing duplicated newlines.
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_preformatted", "elements": [
+				{"type": "text", "text": "line1\nline2\nline3"}
+			]}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	// Expected shape: ```\nline1\nline2\nline3\n``` (trailing newline trimmed).
+	assert.Equal(t, "```\nline1\nline2\nline3\n```", got)
+}
+
+func TestRenderBlocks_QuoteSingleLine(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_quote", "elements": [
+				{"type": "text", "text": "solo"}
+			]}
+		]
+	}]`)
+	// No interior \n in the body — split yields a single-element slice.
+	// Expected output: "> solo" (trailing newline trimmed).
+	assert.Equal(t, "> solo", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_ListItemMalformedJSONIsSkipped(t *testing.T) {
+	// A list with one valid item and one malformed item. The walker must
+	// skip the bad one and still render the good one.
+	// We can't produce "malformed JSON" inside a valid JSON literal, so
+	// construct the blocks by hand with a RawMessage containing garbage.
+	blocks := []Block{{
+		Type: "rich_text",
+		Elements: []json.RawMessage{
+			json.RawMessage(`{
+				"type": "rich_text_list",
+				"style": "bullet",
+				"elements": [
+					{"type": "rich_text_section", "elements": [{"type":"text","text":"good"}]},
+					"not-an-object"
+				]
+			}`),
+		},
+	}}
+	got := RenderBlocks(blocks, nil)
+	assert.Contains(t, got, "- good")
+	// The malformed item must not produce a phantom bullet in the output.
+	lines := strings.Split(got, "\n")
+	bulletLines := 0
+	for _, l := range lines {
+		if strings.HasPrefix(l, "- ") {
+			bulletLines++
+		}
+	}
+	assert.Equal(t, 1, bulletLines, "expected only the good item to render, got %q", got)
+}
+
+func TestRenderBlocks_BroadcastRanges(t *testing.T) {
+	for _, r := range []string{"here", "channel", "everyone"} {
+		t.Run(r, func(t *testing.T) {
+			raw := `[{"type":"rich_text","elements":[
+				{"type":"rich_text_section","elements":[
+					{"type":"broadcast","range":"` + r + `"}
+				]}
+			]}]`
+			blocks := mustBlocks(t, raw)
+			assert.Equal(t, "@"+r, RenderBlocks(blocks, nil))
+		})
+	}
+}
+
+func TestRenderBlocks_DateZeroTimestampNoFallback(t *testing.T) {
+	// Malformed date with both timestamp=0 and empty fallback must
+	// silently emit nothing — letting the message fall back to m.Text
+	// if this was the only inline content.
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [
+			{"type": "rich_text_section", "elements": [
+				{"type": "date", "timestamp": 0, "format": "{date_num}"}
+			]}
+		]
+	}]`)
+	assert.Equal(t, "", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_UnknownBlockAlongsideKnown(t *testing.T) {
+	// A slice with an unknown top-level block followed by a rich_text
+	// block must drop the unknown and still render the known content.
+	blocks := mustBlocks(t, `[
+		{"type": "section", "block_id": "B1"},
+		{"type": "rich_text", "elements": [
+			{"type": "rich_text_section", "elements": [
+				{"type": "text", "text": "survives"}
+			]}
+		]}
+	]`)
+	assert.Equal(t, "survives", RenderBlocks(blocks, nil))
+}
+
 // mustBlocks unmarshals a JSON array into []Block or fails the test.
 func mustBlocks(t *testing.T, raw string) []Block {
 	t.Helper()

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -260,6 +260,7 @@ type Message struct {
 	Edited     *Edited    `json:"edited,omitempty"`
 	Reactions  []Reaction `json:"reactions,omitempty"`
 	Files      []File     `json:"files,omitempty"`
+	Blocks     []Block    `json:"blocks,omitempty"`
 }
 
 // Team represents workspace info

--- a/internal/client/resolver.go
+++ b/internal/client/resolver.go
@@ -23,9 +23,12 @@ func NewUserResolver(c *Client) *UserResolver {
 }
 
 // Resolve returns a display name for the given user ID.
-// It returns the ID unchanged if the lookup fails.
+// It returns the ID unchanged if the lookup fails or the resolver is nil.
 func (r *UserResolver) Resolve(userID string) string {
 	if userID == "" {
+		return userID
+	}
+	if r == nil || r.client == nil {
 		return userID
 	}
 
@@ -60,7 +63,11 @@ func (r *UserResolver) Resolve(userID string) string {
 }
 
 // ResolveMentions replaces <@UXXXXX> mentions in text with display names.
+// Returns text unchanged if the resolver is nil.
 func (r *UserResolver) ResolveMentions(text string) string {
+	if r == nil {
+		return text
+	}
 	return mentionRegex.ReplaceAllStringFunc(text, func(match string) string {
 		sub := mentionRegex.FindStringSubmatch(match)
 		if len(sub) < 2 {

--- a/internal/cmd/messages/history.go
+++ b/internal/cmd/messages/history.go
@@ -64,7 +64,10 @@ func runHistory(channel string, opts *historyOptions, c *client.Client) error {
 	resolver := client.NewUserResolver(c)
 	for _, m := range messages {
 		ts := formatTimestamp(m.TS)
-		text := truncate(resolver.ResolveMentions(m.Text), 80)
+		// Compact view — truncation inherently flattens, so the
+		// blocks-vs-text distinction doesn't matter here.
+		body, _ := messageBody(m, resolver)
+		text := truncate(body, 80)
 		name := resolver.Resolve(m.User)
 		edited := ""
 		if m.Edited != nil {

--- a/internal/cmd/messages/history.go
+++ b/internal/cmd/messages/history.go
@@ -71,6 +71,9 @@ func runHistory(channel string, opts *historyOptions, c *client.Client) error {
 			edited = " [edited]"
 		}
 		output.Printf("[%s] %s: %s%s\n", ts, name, text, edited)
+		if files := renderFiles(m.Files); files != "" {
+			output.Printf("%s", files)
+		}
 	}
 
 	return nil

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -120,7 +120,12 @@ func renderFiles(files []client.File) string {
 }
 
 // humanSize formats a byte count as "411 B", "12.3 KB", "4.5 MB", etc.
+// Slack occasionally returns size=-1 for certain snippet types; clamp
+// negatives to 0 rather than render "-1 B".
 func humanSize(n int64) string {
+	if n < 0 {
+		n = 0
+	}
 	const (
 		kb = 1024
 		mb = 1024 * kb

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -8,6 +8,8 @@ import (
 	"unicode/utf8"
 
 	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
 )
 
 // NewCmd creates the messages command with all subcommands
@@ -59,6 +61,51 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// renderFiles returns one tab-indented "[file] ..." line per attachment, each
+// terminated with "\n". Returns "" when files is empty. The format gives a
+// reader (human or agent) enough context to invoke `slck files download <id>`.
+func renderFiles(files []client.File) string {
+	if len(files) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, f := range files {
+		name := f.Title
+		if name == "" {
+			name = f.Name
+		}
+		b.WriteString("\t[file] ")
+		b.WriteString(name)
+		b.WriteString(" (")
+		b.WriteString(f.Filetype)
+		b.WriteString(", ")
+		b.WriteString(humanSize(f.Size))
+		b.WriteString(") — slck files download ")
+		b.WriteString(f.ID)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+// humanSize formats a byte count as "411 B", "12.3 KB", "4.5 MB", etc.
+func humanSize(n int64) string {
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	switch {
+	case n < kb:
+		return fmt.Sprintf("%d B", n)
+	case n < mb:
+		return fmt.Sprintf("%.1f KB", float64(n)/kb)
+	case n < gb:
+		return fmt.Sprintf("%.1f MB", float64(n)/mb)
+	default:
+		return fmt.Sprintf("%.1f GB", float64(n)/gb)
+	}
 }
 
 // unescapeShellChars removes backslash escaping from common shell-escaped characters.

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -63,6 +63,26 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
+// messageBody chooses the right source for a message's textual content.
+// When blocks render non-empty, returns the rendered body with
+// fromBlocks=true; otherwise returns the mention-resolved m.Text with
+// fromBlocks=false. Callers use fromBlocks to decide whether to preserve
+// newlines (thread detail view) or flatten them (text-only path).
+func messageBody(m client.Message, resolver *client.UserResolver) (body string, fromBlocks bool) {
+	if rendered := client.RenderBlocks(m.Blocks, resolver); rendered != "" {
+		return rendered, true
+	}
+	return resolver.ResolveMentions(m.Text), false
+}
+
+// indentContinuation replaces interior newlines with "\n\t" so that every
+// line after the first is indented under the "[<ts>] <user>:" header.
+// Any trailing newline is trimmed first to avoid a dangling tab.
+func indentContinuation(s string) string {
+	s = strings.TrimRight(s, "\n")
+	return strings.ReplaceAll(s, "\n", "\n\t")
+}
+
 // renderFiles returns one tab-indented "[file] ..." line per attachment, each
 // terminated with "\n". Returns "" when files is empty. The format gives a
 // reader (human or agent) enough context to invoke `slck files download <id>`.

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -96,6 +96,12 @@ func renderFiles(files []client.File) string {
 		if name == "" {
 			name = f.Name
 		}
+		if name == "" {
+			// Slack can return both title and name empty for anonymous
+			// snippets or certain file-sharing events. Fall back to the
+			// file ID so the line never renders as "[file]  (...)".
+			name = f.ID
+		}
 		b.WriteString("\t[file] ")
 		b.WriteString(name)
 		b.WriteString(" (")

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -99,8 +99,12 @@ func renderFiles(files []client.File) string {
 		b.WriteString("\t[file] ")
 		b.WriteString(name)
 		b.WriteString(" (")
-		b.WriteString(f.Filetype)
-		b.WriteString(", ")
+		// Slack occasionally omits filetype; drop the type clause rather
+		// than emit "(, 411 B)".
+		if f.Filetype != "" {
+			b.WriteString(f.Filetype)
+			b.WriteString(", ")
+		}
 		b.WriteString(humanSize(f.Size))
 		b.WriteString(") — slck files download ")
 		b.WriteString(f.ID)

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1725,21 +1725,24 @@ func TestMessageBody_NilResolverTextPath(t *testing.T) {
 
 func TestHumanSize(t *testing.T) {
 	tests := []struct {
+		name     string
 		n        int64
 		expected string
 	}{
-		{0, "0 B"},
-		{1, "1 B"},
-		{411, "411 B"},
-		{1023, "1023 B"},
-		{1024, "1.0 KB"},
-		{12345, "12.1 KB"},
-		{1024 * 1024, "1.0 MB"},
-		{4_718_592, "4.5 MB"},
-		{1024 * 1024 * 1024, "1.0 GB"},
+		{"zero", 0, "0 B"},
+		{"one byte", 1, "1 B"},
+		{"411 B", 411, "411 B"},
+		{"1023 B boundary", 1023, "1023 B"},
+		{"1 KB boundary", 1024, "1.0 KB"},
+		{"KB mid-range", 12345, "12.1 KB"},
+		{"1 MB boundary", 1024 * 1024, "1.0 MB"},
+		{"MB mid-range", 4_718_592, "4.5 MB"},
+		{"1 GB boundary", 1024 * 1024 * 1024, "1.0 GB"},
+		{"negative one clamps to zero", -1, "0 B"},
+		{"negative large clamps to zero", -12345, "0 B"},
 	}
 	for _, tt := range tests {
-		t.Run(tt.expected, func(t *testing.T) {
+		t.Run(tt.name, func(t *testing.T) {
 			assert.Equal(t, tt.expected, humanSize(tt.n))
 		})
 	}
@@ -2108,6 +2111,81 @@ func TestRunThread_MultilineBlocksIndentContinuationLines(t *testing.T) {
 		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
 	})
 	assert.Contains(t, out, "line1\n\tline2", "expected continuation line indented with tab")
+}
+
+func TestRunThread_EditedMarkerOnFirstLineForMultilineBlocks(t *testing.T) {
+	// When a block-rendered message is edited, [edited] should land on
+	// the first line so it annotates the whole message — otherwise it
+	// looks like it's annotating only the final continuation line.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":     "1234567890.123456",
+						"user":   "U001",
+						"text":   "",
+						"edited": map[string]interface{}{"user": "U001", "ts": "1234567890.200000"},
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{"type": "rich_text_section", "elements": []map[string]interface{}{{"type": "text", "text": "line1"}}},
+									{"type": "rich_text_section", "elements": []map[string]interface{}{{"type": "text", "text": "line2"}}},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	// [edited] should be on the header line ("line1 [edited]"), not after "line2".
+	assert.Contains(t, out, "line1 [edited]\n\tline2")
+	assert.NotContains(t, out, "line2 [edited]")
+}
+
+func TestRunThread_EditedMarkerUnchangedForSingleLineBody(t *testing.T) {
+	// No regression: single-line messages still get [edited] at the end.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":     "1234567890.123456",
+						"user":   "U001",
+						"text":   "plain body",
+						"edited": map[string]interface{}{"user": "U001", "ts": "1234567890.200000"},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "plain body [edited]")
 }
 
 func TestRunThread_PreservesFlattenForTextOnlyMultilineMessage(t *testing.T) {

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1790,6 +1790,17 @@ func TestRenderFiles(t *testing.T) {
 		got := renderFiles([]client.File{{ID: "F1", Name: "a.csv", Filetype: "csv", Size: 100}})
 		assert.True(t, strings.HasPrefix(got, "\t"), "expected line to start with tab, got %q", got)
 	})
+
+	t.Run("empty filetype drops the type clause", func(t *testing.T) {
+		got := renderFiles([]client.File{{
+			ID:   "F0ABC",
+			Name: "data",
+			Size: 411,
+		}})
+		// Must NOT emit "(, 411 B)" — drop the type clause entirely when Filetype is empty.
+		assert.Equal(t, "\t[file] data (411 B) — slck files download F0ABC\n", got)
+		assert.NotContains(t, got, "(, ")
+	})
 }
 
 // captureTextOutput captures text output for a test function and resets state.
@@ -2163,6 +2174,66 @@ func TestRunHistory_BlocksTruncatedToEightyChars(t *testing.T) {
 	// contain more than 77 x's in a row plus "...".
 	assert.Contains(t, out, "xxx...")
 	assert.NotContains(t, out, strings.Repeat("x", 100))
+}
+
+func TestRunHistory_MultiSectionBlocksStayOnOneLine(t *testing.T) {
+	// Regression guard: history's compact view must render multi-section
+	// rich_text blocks on one line even when the combined body is short
+	// enough that truncation would not trigger. truncate() flattens
+	// newlines unconditionally at its first step, and this test locks
+	// that behavior in.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.history":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": "first"},
+										},
+									},
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": "second"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &historyOptions{limit: 20}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runHistory("C123", opts, c))
+	})
+	// The message line must contain both sections joined by a space on a
+	// single line — no embedded newline inside the rendered body.
+	assert.Contains(t, out, "first second")
+	assert.NotContains(t, out, "first\nsecond")
+	// Exactly one line for the single message (plus the trailing newline
+	// from output.Printf's \n format string).
+	lines := strings.Split(strings.TrimRight(out, "\n"), "\n")
+	assert.Len(t, lines, 1, "expected single output line, got %d: %q", len(lines), out)
 }
 
 func TestRunThread_JSONIncludesBlocks(t *testing.T) {

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1692,6 +1692,37 @@ func TestRunSend_FileUpload_LongTextAllowed(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestIndentContinuation(t *testing.T) {
+	tests := []struct {
+		name, input, expected string
+	}{
+		{"single line no-op", "hello", "hello"},
+		{"interior newline indents continuation", "line1\nline2", "line1\n\tline2"},
+		{"trailing newline trimmed", "line1\n", "line1"},
+		{"multiple interior newlines", "a\nb\nc", "a\n\tb\n\tc"},
+		{"trailing newline trimmed with interior newlines", "a\nb\n", "a\n\tb"},
+		{"empty string", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, indentContinuation(tt.input))
+		})
+	}
+}
+
+func TestMessageBody_NilResolverTextPath(t *testing.T) {
+	// Regression guard: the text-only path calls ResolveMentions on the
+	// resolver. If the nil-guard were ever removed from ResolveMentions,
+	// this test would panic. The blocks path is covered by
+	// TestRenderBlocks_NilResolverDoesNotPanic in the client package.
+	m := client.Message{Text: "hello <@U123>"}
+	body, fromBlocks := messageBody(m, nil)
+	assert.False(t, fromBlocks)
+	// Mentions are not resolved when the resolver is nil; the raw form
+	// survives.
+	assert.Equal(t, "hello <@U123>", body)
+}
+
 func TestHumanSize(t *testing.T) {
 	tests := []struct {
 		n        int64
@@ -2223,10 +2254,10 @@ func TestRunHistory_TextIncludesFileHints(t *testing.T) {
 		require.NoError(t, runHistory("C123", opts, c))
 	})
 
-	assert.Contains(t, out, "[file]")
-	assert.Contains(t, out, "IW Trailer.pdf")
-	assert.Contains(t, out, "pdf")
-	assert.Contains(t, out, "slck files download F0ATD4WJ70D")
-	// File hint must render in full even though the message body is truncated
+	// The full hint line must appear verbatim even when the message body
+	// has been truncated to 80 chars. A truncation bug that clipped the
+	// hint after a certain point would not be caught by Contains checks
+	// of the individual fragments alone.
+	assert.Contains(t, out, "\t[file] IW Trailer.pdf (pdf, 59.2 KB) — slck files download F0ATD4WJ70D\n")
 	assert.NotContains(t, out, "...F0ATD4WJ70D")
 }

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1691,3 +1691,170 @@ func TestRunSend_FileUpload_LongTextAllowed(t *testing.T) {
 	err = runSend("C123456789", longText, opts, c)
 	require.NoError(t, err)
 }
+
+func TestHumanSize(t *testing.T) {
+	tests := []struct {
+		n        int64
+		expected string
+	}{
+		{0, "0 B"},
+		{1, "1 B"},
+		{411, "411 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{12345, "12.1 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{4_718_592, "4.5 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			assert.Equal(t, tt.expected, humanSize(tt.n))
+		})
+	}
+}
+
+func TestRenderFiles(t *testing.T) {
+	t.Run("empty returns empty string", func(t *testing.T) {
+		assert.Equal(t, "", renderFiles(nil))
+		assert.Equal(t, "", renderFiles([]client.File{}))
+	})
+
+	t.Run("single file uses name when title is empty", func(t *testing.T) {
+		got := renderFiles([]client.File{{
+			ID:       "F0ABC",
+			Name:     "data.csv",
+			Filetype: "csv",
+			Size:     411,
+		}})
+		assert.Equal(t, "\t[file] data.csv (csv, 411 B) — slck files download F0ABC\n", got)
+	})
+
+	t.Run("title takes precedence over name", func(t *testing.T) {
+		got := renderFiles([]client.File{{
+			ID:       "F0ABC",
+			Name:     "raw_upload_12345.png",
+			Title:    "Screenshot",
+			Filetype: "png",
+			Size:     54321,
+		}})
+		assert.Contains(t, got, "Screenshot")
+		assert.NotContains(t, got, "raw_upload_12345.png")
+	})
+
+	t.Run("multiple files render one line each", func(t *testing.T) {
+		got := renderFiles([]client.File{
+			{ID: "F1", Name: "a.csv", Filetype: "csv", Size: 100},
+			{ID: "F2", Name: "b.pdf", Filetype: "pdf", Size: 2048},
+		})
+		lines := strings.Split(strings.TrimRight(got, "\n"), "\n")
+		require.Len(t, lines, 2)
+		assert.Contains(t, lines[0], "F1")
+		assert.Contains(t, lines[0], "a.csv")
+		assert.Contains(t, lines[1], "F2")
+		assert.Contains(t, lines[1], "b.pdf")
+	})
+
+	t.Run("each line starts with tab prefix", func(t *testing.T) {
+		got := renderFiles([]client.File{{ID: "F1", Name: "a.csv", Filetype: "csv", Size: 100}})
+		assert.True(t, strings.HasPrefix(got, "\t"), "expected line to start with tab, got %q", got)
+	})
+}
+
+// captureTextOutput captures text output for a test function and resets state.
+func captureTextOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	origWriter := output.Writer
+	output.Writer = &buf
+	defer func() { output.Writer = origWriter }()
+	fn()
+	return buf.String()
+}
+
+func TestRunThread_TextIncludesFileHints(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "Here are the check files",
+						"files": []map[string]interface{}{
+							{
+								"id":       "F0AT13FGVAT",
+								"name":     "data.csv",
+								"filetype": "csv",
+								"size":     411,
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+
+	assert.Contains(t, out, "[file]")
+	assert.Contains(t, out, "data.csv")
+	assert.Contains(t, out, "csv")
+	assert.Contains(t, out, "411 B")
+	assert.Contains(t, out, "slck files download F0AT13FGVAT")
+}
+
+func TestRunHistory_TextIncludesFileHints(t *testing.T) {
+	// Message text intentionally long to ensure file hint still renders in full
+	longText := "This is a very long message body that definitely exceeds eighty characters and will be truncated in history's compact view."
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.history":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": longText,
+						"files": []map[string]interface{}{
+							{
+								"id":       "F0ATD4WJ70D",
+								"name":     "IW Trailer.pdf",
+								"filetype": "pdf",
+								"size":     60646,
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &historyOptions{limit: 20}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runHistory("C123", opts, c))
+	})
+
+	assert.Contains(t, out, "[file]")
+	assert.Contains(t, out, "IW Trailer.pdf")
+	assert.Contains(t, out, "pdf")
+	assert.Contains(t, out, "slck files download F0ATD4WJ70D")
+	// File hint must render in full even though the message body is truncated
+	assert.NotContains(t, out, "...F0ATD4WJ70D")
+}

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1814,6 +1814,378 @@ func TestRunThread_TextIncludesFileHints(t *testing.T) {
 	assert.Contains(t, out, "slck files download F0AT13FGVAT")
 }
 
+func TestRunThread_RendersRichTextBlocks(t *testing.T) {
+	// Message with empty text and a rich_text block containing a section.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": "Account Number Check Number"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "Account Number Check Number")
+}
+
+func TestRunThread_BlocksOverrideNonEmptyText(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "FALLBACK_TEXT_SENTINEL",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": "FROM_BLOCKS"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "FROM_BLOCKS")
+	assert.NotContains(t, out, "FALLBACK_TEXT_SENTINEL")
+}
+
+func TestRunThread_FallsBackToTextWhenSubBlocksUnrenderable(t *testing.T) {
+	// Blocks contain only unknown rich_text sub-types → renderer yields
+	// empty → fall back to m.Text.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "FALLBACK_TEXT",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{"type": "rich_text_future_kind", "elements": []map[string]interface{}{}},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "FALLBACK_TEXT")
+}
+
+func TestRunThread_FallsBackToTextWhenInlineElementsUnrenderable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "INLINE_FALLBACK",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "future_inline", "text": "ignored"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "INLINE_FALLBACK")
+}
+
+func TestRunThread_FallsBackToTextWhenBlocksNil(t *testing.T) {
+	// No regression on the common path: no blocks → m.Text renders as before.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{"ts": "1234567890.123456", "user": "U001", "text": "plain old text"},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "plain old text")
+}
+
+func TestRunThread_MultilineBlocksIndentContinuationLines(t *testing.T) {
+	// A rich_text block with two sections renders as two lines; the
+	// second line must be indented with \t under the header.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": "line1"},
+										},
+									},
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": "line2"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "line1\n\tline2", "expected continuation line indented with tab")
+}
+
+func TestRunThread_PreservesFlattenForTextOnlyMultilineMessage(t *testing.T) {
+	// Regression guard: plain-text messages with newlines should still be
+	// flattened when no blocks are present.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{"ts": "1234567890.123456", "user": "U001", "text": "line1\nline2"},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
+	})
+	assert.Contains(t, out, "line1 line2")
+	assert.NotContains(t, out, "line1\nline2")
+	assert.NotContains(t, out, "line1\n\tline2")
+}
+
+func TestRunHistory_BlocksTruncatedToEightyChars(t *testing.T) {
+	// History's compact view must still respect the 80-char cap even when
+	// content comes from blocks.
+	longText := strings.Repeat("x", 200)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.history":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": longText},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &historyOptions{limit: 20}
+
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runHistory("C123", opts, c))
+	})
+	// truncate() caps at 80 chars including "...", so the body must not
+	// contain more than 77 x's in a row plus "...".
+	assert.Contains(t, out, "xxx...")
+	assert.NotContains(t, out, strings.Repeat("x", 100))
+}
+
+func TestRunThread_JSONIncludesBlocks(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "rich_text",
+								"elements": []map[string]interface{}{
+									{
+										"type": "rich_text_section",
+										"elements": []map[string]interface{}{
+											{"type": "text", "text": "hello"},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &threadOptions{limit: 100}
+
+	output.OutputFormat = output.FormatJSON
+	defer func() { output.OutputFormat = output.FormatText }()
+	var buf strings.Builder
+	output.Writer = &buf
+	defer func() { output.Writer = os.Stdout }()
+
+	err := runThread("C123", "1234567890.123456", opts, c)
+	require.NoError(t, err)
+
+	var messages []client.Message
+	require.NoError(t, json.Unmarshal([]byte(buf.String()), &messages))
+	require.Len(t, messages, 1)
+	require.Len(t, messages[0].Blocks, 1)
+	assert.Equal(t, "rich_text", messages[0].Blocks[0].Type)
+}
+
 func TestRunHistory_TextIncludesFileHints(t *testing.T) {
 	// Message text intentionally long to ensure file hint still renders in full
 	longText := "This is a very long message body that definitely exceeds eighty characters and will be truncated in history's compact view."

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1791,6 +1791,17 @@ func TestRenderFiles(t *testing.T) {
 		assert.True(t, strings.HasPrefix(got, "\t"), "expected line to start with tab, got %q", got)
 	})
 
+	t.Run("empty name and title falls back to file ID", func(t *testing.T) {
+		got := renderFiles([]client.File{{
+			ID:       "F0ABC",
+			Filetype: "csv",
+			Size:     411,
+		}})
+		// Must NOT emit "[file]  (csv, 411 B)" with a blank display name.
+		assert.Equal(t, "\t[file] F0ABC (csv, 411 B) — slck files download F0ABC\n", got)
+		assert.NotContains(t, got, "[file]  (")
+	})
+
 	t.Run("empty filetype drops the type clause", func(t *testing.T) {
 		got := renderFiles([]client.File{{
 			ID:   "F0ABC",

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -73,6 +73,9 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 			edited = " [edited]"
 		}
 		output.Printf("[%s] %s: %s%s\n", ts, name, text, edited)
+		if files := renderFiles(m.Files); files != "" {
+			output.Printf("%s", files)
+		}
 	}
 
 	return nil

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -1,6 +1,8 @@
 package messages
 
 import (
+	"strings"
+
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
@@ -80,6 +82,15 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 		edited := ""
 		if m.Edited != nil {
 			edited = " [edited]"
+		}
+		// For multi-line bodies, place [edited] on the first line so it
+		// annotates the whole message rather than appearing to annotate
+		// only the final continuation line.
+		if edited != "" {
+			if idx := strings.Index(text, "\n"); idx >= 0 {
+				text = text[:idx] + edited + text[idx:]
+				edited = ""
+			}
 		}
 		output.Printf("[%s] %s: %s%s\n", ts, name, text, edited)
 		if files := renderFiles(m.Files); files != "" {

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -66,7 +66,16 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 	resolver := client.NewUserResolver(c)
 	for _, m := range messages {
 		ts := formatTimestamp(m.TS)
-		text := flatten(resolver.ResolveMentions(m.Text))
+		body, fromBlocks := messageBody(m, resolver)
+		var text string
+		if fromBlocks {
+			// Preserve newlines from rendered blocks; indent continuation
+			// lines so multi-line content stays visually grouped.
+			text = indentContinuation(body)
+		} else {
+			// Plain-text fallback keeps existing single-line behavior.
+			text = flatten(body)
+		}
 		name := resolver.Resolve(m.User)
 		edited := ""
 		if m.Edited != nil {


### PR DESCRIPTION
## Summary

- Render file attachments as tab-indented `[file] <name> (<type>, <size>) — slck files download <id>` lines after the message in `slck messages thread` and `slck messages history`. Previously `m.Files` was populated but the text renderer dropped it entirely, leaving readers (humans or agents) with no hint that attachments existed.
- Render Slack rich-text blocks that come through with empty `m.Text` (common when a user pastes a formatted table with CMD+V). A new `Block`/`RichTextElement` model plus `RenderBlocks` walker handles all rich-text sub-types (sections, lists with honored `offset`, preformatted, quotes) and inline element types (text with bold/italic/code/strike, link, user, channel, emoji, broadcast, usergroup, date). Unknown types silently drop so `m.Text` fallback wins when rendering would yield nothing useful.
- Thread preserves newlines from block-rendered bodies and indents continuation lines under the `[<ts>] <user>:` header. Plain-text messages keep their existing single-line rendering — no regression for the common path. History's compact view still truncates to 80 chars.
- `UserResolver.Resolve` and `ResolveMentions` are now nil-safe so `RenderBlocks` can be called with a nil resolver without panicking.

## Test plan

- [x] `make test` — 588 passed across 18 packages (36 new)
- [x] `make lint` — 0 issues
- [x] Manual verification against the reproducer thread: previously-blank table-paste messages now render their content; file-upload messages show `[file] ... slck files download <id>` hints.
- [x] `--output json` still exposes the `files` array and now also exposes `blocks` unchanged.

Closes #141