### PR TITLE
fix(messages): render full message text from blocks/attachments/files

### DIFF
--- a/internal/client/blocks.go
+++ b/internal/client/blocks.go
@@ -139,23 +139,176 @@ func (e RichTextElement) MarshalJSON() ([]byte, error) {
 
 // RenderBlocks walks top-level blocks and returns plain text suitable for
 // slck's text output. Returns "" if blocks is empty or no block yields
-// output — callers can use that signal to fall back to m.Text. Safe to
-// call with a nil resolver.
+// output. Handles rich_text along with the common Block Kit surface
+// types (section, header, context, actions, image, video). Safe to call
+// with a nil resolver.
 func RenderBlocks(blocks []Block, resolver *UserResolver) string {
 	if len(blocks) == 0 {
 		return ""
 	}
-	var out strings.Builder
+	var rendered []string
 	for _, b := range blocks {
-		if b.Type != "rich_text" {
-			// Non-rich_text blocks (section, image, context, etc.) are
-			// dropped so the caller falls back to m.Text, which Slack
-			// populates as a plain-text equivalent for these cases.
+		var piece string
+		switch b.Type {
+		case "rich_text":
+			piece = strings.TrimRight(renderRichText(b.Elements, resolver, 0), "\n")
+		case "section":
+			piece = renderSectionBlock(b.raw)
+		case "header":
+			piece = renderHeaderBlock(b.raw)
+		case "context":
+			piece = renderContextBlock(b.raw)
+		case "actions":
+			piece = renderActionsBlock(b.raw)
+		case "image":
+			piece = renderImageBlock(b.raw)
+		case "video":
+			piece = renderVideoBlock(b.raw)
+		default:
+			// divider and unknown types — drop.
+		}
+		if piece != "" {
+			rendered = append(rendered, piece)
+		}
+	}
+	return strings.Join(rendered, "\n")
+}
+
+// blockText is the shape of a {type, text, emoji?} text object embedded
+// in many block types (section.text, header.text, context.elements[], etc.).
+type blockText struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+func renderSectionBlock(raw json.RawMessage) string {
+	var s struct {
+		Text   *blockText  `json:"text"`
+		Fields []blockText `json:"fields"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	var pieces []string
+	if s.Text != nil && strings.TrimSpace(s.Text.Text) != "" {
+		pieces = append(pieces, s.Text.Text)
+	}
+	if line := joinFieldTexts(s.Fields); line != "" {
+		pieces = append(pieces, line)
+	}
+	return strings.Join(pieces, "\n")
+}
+
+func joinFieldTexts(fields []blockText) string {
+	var parts []string
+	for _, f := range fields {
+		if t := strings.TrimSpace(f.Text); t != "" {
+			parts = append(parts, t)
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+func renderHeaderBlock(raw json.RawMessage) string {
+	var s struct {
+		Text *blockText `json:"text"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil || s.Text == nil {
+		return ""
+	}
+	return strings.TrimSpace(s.Text.Text)
+}
+
+func renderContextBlock(raw json.RawMessage) string {
+	var s struct {
+		Elements []struct {
+			Type    string `json:"type"`
+			Text    string `json:"text"`
+			AltText string `json:"alt_text"`
+		} `json:"elements"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	var parts []string
+	for _, e := range s.Elements {
+		switch e.Type {
+		case "plain_text", "mrkdwn":
+			if t := strings.TrimSpace(e.Text); t != "" {
+				parts = append(parts, t)
+			}
+		case "image":
+			if alt := strings.TrimSpace(e.AltText); alt != "" {
+				parts = append(parts, alt)
+			}
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func renderActionsBlock(raw json.RawMessage) string {
+	var s struct {
+		Elements []struct {
+			Type string     `json:"type"`
+			Text *blockText `json:"text"`
+		} `json:"elements"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	var parts []string
+	for _, e := range s.Elements {
+		if e.Text == nil {
 			continue
 		}
-		out.WriteString(renderRichText(b.Elements, resolver, 0))
+		if t := strings.TrimSpace(e.Text.Text); t != "" {
+			parts = append(parts, "["+t+"]")
+		}
 	}
-	return strings.TrimRight(out.String(), "\n")
+	return strings.Join(parts, " ")
+}
+
+func renderImageBlock(raw json.RawMessage) string {
+	var s struct {
+		AltText string     `json:"alt_text"`
+		Title   *blockText `json:"title"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	if alt := strings.TrimSpace(s.AltText); alt != "" {
+		return alt
+	}
+	if s.Title != nil {
+		return strings.TrimSpace(s.Title.Text)
+	}
+	return ""
+}
+
+func renderVideoBlock(raw json.RawMessage) string {
+	var s struct {
+		Title       *blockText `json:"title"`
+		Description *blockText `json:"description"`
+		AltText     string     `json:"alt_text"`
+	}
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	var pieces []string
+	if s.Title != nil {
+		if t := strings.TrimSpace(s.Title.Text); t != "" {
+			pieces = append(pieces, t)
+		}
+	}
+	if s.Description != nil {
+		if t := strings.TrimSpace(s.Description.Text); t != "" {
+			pieces = append(pieces, t)
+		}
+	}
+	if len(pieces) > 0 {
+		return strings.Join(pieces, "\n")
+	}
+	return strings.TrimSpace(s.AltText)
 }
 
 // renderRichText walks the sub-elements of a rich_text block.

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -232,15 +232,22 @@ type Reaction struct {
 
 // File represents a file attachment on a Slack message
 type File struct {
-	ID                 string `json:"id"`
-	Name               string `json:"name"`
-	Title              string `json:"title,omitempty"`
-	Mimetype           string `json:"mimetype,omitempty"`
-	Filetype           string `json:"filetype,omitempty"`
-	Size               int64  `json:"size,omitempty"`
-	URLPrivate         string `json:"url_private,omitempty"`
-	URLPrivateDownload string `json:"url_private_download,omitempty"`
-	Permalink          string `json:"permalink,omitempty"`
+	ID                 string       `json:"id"`
+	Name               string       `json:"name"`
+	Title              string       `json:"title,omitempty"`
+	Mimetype           string       `json:"mimetype,omitempty"`
+	Filetype           string       `json:"filetype,omitempty"`
+	Size               int64        `json:"size,omitempty"`
+	URLPrivate         string       `json:"url_private,omitempty"`
+	URLPrivateDownload string       `json:"url_private_download,omitempty"`
+	Permalink          string       `json:"permalink,omitempty"`
+	PlainText          string       `json:"plain_text,omitempty"`
+	InitialComment     *FileComment `json:"initial_comment,omitempty"`
+}
+
+// FileComment represents the comment posted alongside a shared file.
+type FileComment struct {
+	Comment string `json:"comment,omitempty"`
 }
 
 // Edited represents the edit metadata for an edited Slack message
@@ -251,16 +258,17 @@ type Edited struct {
 
 // Message represents a Slack message
 type Message struct {
-	Type       string     `json:"type"`
-	User       string     `json:"user"`
-	Text       string     `json:"text"`
-	TS         string     `json:"ts"`
-	ThreadTS   string     `json:"thread_ts,omitempty"`
-	ReplyCount int        `json:"reply_count,omitempty"`
-	Edited     *Edited    `json:"edited,omitempty"`
-	Reactions  []Reaction `json:"reactions,omitempty"`
-	Files      []File     `json:"files,omitempty"`
-	Blocks     []Block    `json:"blocks,omitempty"`
+	Type        string       `json:"type"`
+	User        string       `json:"user"`
+	Text        string       `json:"text"`
+	TS          string       `json:"ts"`
+	ThreadTS    string       `json:"thread_ts,omitempty"`
+	ReplyCount  int          `json:"reply_count,omitempty"`
+	Edited      *Edited      `json:"edited,omitempty"`
+	Reactions   []Reaction   `json:"reactions,omitempty"`
+	Files       []File       `json:"files,omitempty"`
+	Blocks      []Block      `json:"blocks,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
 // Team represents workspace info
@@ -277,11 +285,14 @@ type SearchMatch struct {
 		ID   string `json:"id"`
 		Name string `json:"name"`
 	} `json:"channel"`
-	User      string `json:"user"`
-	Username  string `json:"username"`
-	Text      string `json:"text"`
-	TS        string `json:"ts"`
-	Permalink string `json:"permalink"`
+	User        string       `json:"user"`
+	Username    string       `json:"username"`
+	Text        string       `json:"text"`
+	TS          string       `json:"ts"`
+	Permalink   string       `json:"permalink"`
+	Blocks      []Block      `json:"blocks,omitempty"`
+	Files       []File       `json:"files,omitempty"`
+	Attachments []Attachment `json:"attachments,omitempty"`
 }
 
 // FileMatch represents a file match from search

--- a/internal/client/message_render.go
+++ b/internal/client/message_render.go
@@ -113,9 +113,12 @@ func RenderMessage(c MessageContent, resolver MentionResolver) RenderedMessage {
 }
 
 // textDuplicatesAnyPiece reports whether text matches (after whitespace
-// normalization) the rendering of any single richer piece. Per-piece
-// rather than aggregate comparison so a multi-surface message doesn't
-// double-print text that mirrors only the blocks rendering.
+// normalization) the rendering of any single richer piece OR the
+// newline-joined aggregate. Per-piece comparison handles the common
+// Block-Kit fallback case where text mirrors blocks while attachments
+// add separate content; aggregate comparison handles the multi-block
+// case where Slack's text fallback is the joined rendering of every
+// block.
 func textDuplicatesAnyPiece(text string, pieces []string) bool {
 	norm := normalizeWhitespace(text)
 	if norm == "" {
@@ -126,7 +129,7 @@ func textDuplicatesAnyPiece(text string, pieces []string) bool {
 			return true
 		}
 	}
-	return false
+	return normalizeWhitespace(strings.Join(pieces, "\n")) == norm
 }
 
 func normalizeWhitespace(s string) string {
@@ -180,6 +183,7 @@ func renderAttachment(a Attachment, resolver MentionResolver) string {
 	}
 
 	addTrimmed(a.Pretext)
+	addTrimmed(a.AuthorName)
 	addTrimmed(a.Title)
 	addTrimmed(a.Text)
 

--- a/internal/client/message_render.go
+++ b/internal/client/message_render.go
@@ -33,8 +33,8 @@ type RenderedMessage struct {
 
 // Attachment is the legacy pre-Block-Kit message attachment shape. Only
 // the readable fields are typed; the rest round-trips via raw bytes so
-// --output json stays byte-identical at unmodeled keys (color, mrkdwn_in,
-// callback_id, image_url, actions, ts, etc.).
+// --output json preserves unknown fields the typed struct doesn't model
+// (color, mrkdwn_in, callback_id, image_url, actions, ts, etc.).
 type Attachment struct {
 	Pretext    string            `json:"pretext,omitempty"`
 	Title      string            `json:"title,omitempty"`

--- a/internal/client/message_render.go
+++ b/internal/client/message_render.go
@@ -1,0 +1,263 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"unicode/utf8"
+)
+
+// MentionResolver is the renderer's only I/O boundary. *UserResolver
+// satisfies it; the renderer is otherwise pure given a nil or fake resolver.
+type MentionResolver interface {
+	Resolve(userID string) string
+	ResolveMentions(text string) string
+}
+
+// MessageContent is the readable surface of a Slack message that the
+// renderer walks. Search results and channel history both populate it.
+type MessageContent struct {
+	Text        string
+	Blocks      []Block
+	Attachments []Attachment
+	Files       []File
+}
+
+// RenderedMessage is the renderer's output. PreserveNewlines is true when
+// the body came from a richer surface (blocks/attachments/files); callers
+// that flatten plain-text in compact views should leave PreserveNewlines
+// content alone.
+type RenderedMessage struct {
+	Body             string
+	PreserveNewlines bool
+}
+
+// Attachment is the legacy pre-Block-Kit message attachment shape. Only
+// the readable fields are typed; the rest round-trips via raw bytes so
+// --output json stays byte-identical at unmodeled keys (color, mrkdwn_in,
+// callback_id, image_url, actions, ts, etc.).
+type Attachment struct {
+	Pretext    string            `json:"pretext,omitempty"`
+	Title      string            `json:"title,omitempty"`
+	Text       string            `json:"text,omitempty"`
+	Fallback   string            `json:"fallback,omitempty"`
+	AuthorName string            `json:"author_name,omitempty"`
+	Footer     string            `json:"footer,omitempty"`
+	Fields     []AttachmentField `json:"fields,omitempty"`
+	Blocks     []Block           `json:"blocks,omitempty"`
+
+	raw json.RawMessage
+}
+
+// AttachmentField is one entry in attachment.fields[].
+type AttachmentField struct {
+	Title string `json:"title,omitempty"`
+	Value string `json:"value,omitempty"`
+	Short bool   `json:"short,omitempty"`
+}
+
+// UnmarshalJSON captures the raw bytes alongside the typed fields so that
+// attachments with fields outside the typed struct can be re-emitted
+// without loss.
+func (a *Attachment) UnmarshalJSON(data []byte) error {
+	a.raw = append(a.raw[:0], data...)
+	type alias Attachment
+	return json.Unmarshal(data, (*alias)(a))
+}
+
+// MarshalJSON emits the original raw bytes when available so unmodeled
+// fields survive an unmarshal/marshal cycle. Falls back to the typed
+// alias for attachments built in code (no raw captured).
+func (a Attachment) MarshalJSON() ([]byte, error) {
+	if len(a.raw) > 0 {
+		return a.raw, nil
+	}
+	type alias Attachment
+	return json.Marshal(alias(a))
+}
+
+// RenderMessage produces a token-dense plain-text rendering of a Slack
+// message's readable surfaces. Walks blocks, attachments, then files.
+// Falls back to mention-resolved Text when no richer surface yields
+// content. Top-level Text is prepended when the richer surfaces rendered
+// content but Text isn't a duplicate of any individual rendered piece.
+func RenderMessage(c MessageContent, resolver MentionResolver) RenderedMessage {
+	pieces := make([]string, 0, 3)
+	if rendered := renderBlocksWithResolver(c.Blocks, resolver); rendered != "" {
+		pieces = append(pieces, rendered)
+	}
+	if rendered := renderAttachments(c.Attachments, resolver); rendered != "" {
+		pieces = append(pieces, rendered)
+	}
+	if rendered := renderFilesText(c.Files); rendered != "" {
+		pieces = append(pieces, rendered)
+	}
+
+	if len(pieces) == 0 {
+		body := c.Text
+		if resolver != nil {
+			body = resolver.ResolveMentions(c.Text)
+		}
+		return RenderedMessage{Body: body, PreserveNewlines: false}
+	}
+
+	richer := strings.Join(pieces, "\n")
+	resolvedText := c.Text
+	if resolver != nil {
+		resolvedText = resolver.ResolveMentions(c.Text)
+	}
+
+	if strings.TrimSpace(resolvedText) != "" && !textDuplicatesAnyPiece(resolvedText, pieces) {
+		return RenderedMessage{Body: resolvedText + "\n" + richer, PreserveNewlines: true}
+	}
+	return RenderedMessage{Body: richer, PreserveNewlines: true}
+}
+
+// textDuplicatesAnyPiece reports whether text matches (after whitespace
+// normalization) the rendering of any single richer piece. Per-piece
+// rather than aggregate comparison so a multi-surface message doesn't
+// double-print text that mirrors only the blocks rendering.
+func textDuplicatesAnyPiece(text string, pieces []string) bool {
+	norm := normalizeWhitespace(text)
+	if norm == "" {
+		return true
+	}
+	for _, p := range pieces {
+		if normalizeWhitespace(p) == norm {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeWhitespace(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// renderBlocksWithResolver bridges the MentionResolver interface to the
+// existing *UserResolver-typed RenderBlocks. nil resolver passes through.
+func renderBlocksWithResolver(blocks []Block, resolver MentionResolver) string {
+	if ur, ok := resolver.(*UserResolver); ok {
+		return RenderBlocks(blocks, ur)
+	}
+	// Either nil or a non-UserResolver implementation. RenderBlocks today
+	// is parameterized on *UserResolver, but the only methods it invokes
+	// are nil-safe. Pass nil through; future tests using a fake resolver
+	// can call RenderBlocks directly.
+	return RenderBlocks(blocks, nil)
+}
+
+func renderAttachments(atts []Attachment, resolver MentionResolver) string {
+	if len(atts) == 0 {
+		return ""
+	}
+	var rendered []string
+	for _, a := range atts {
+		if r := renderAttachment(a, resolver); r != "" {
+			rendered = append(rendered, r)
+		}
+	}
+	return strings.Join(rendered, "\n")
+}
+
+func renderAttachment(a Attachment, resolver MentionResolver) string {
+	var pieces []string
+	addNonEmpty := func(s string) {
+		if s != "" {
+			pieces = append(pieces, s)
+		}
+	}
+
+	addNonEmpty(a.Pretext)
+	addNonEmpty(a.Title)
+	addNonEmpty(a.Text)
+
+	if line := renderAttachmentFields(a.Fields); line != "" {
+		pieces = append(pieces, line)
+	}
+
+	if blocks := renderBlocksWithResolver(a.Blocks, resolver); blocks != "" {
+		pieces = append(pieces, blocks)
+	}
+
+	addNonEmpty(a.Footer)
+
+	if len(pieces) == 0 {
+		// Fallback only when nothing else from the attachment rendered.
+		return strings.TrimSpace(a.Fallback)
+	}
+	return strings.Join(pieces, "\n")
+}
+
+func renderAttachmentFields(fields []AttachmentField) string {
+	if len(fields) == 0 {
+		return ""
+	}
+	var parts []string
+	for _, f := range fields {
+		title := strings.TrimSpace(f.Title)
+		value := strings.TrimSpace(f.Value)
+		switch {
+		case title != "" && value != "":
+			parts = append(parts, title+": "+value)
+		case value != "":
+			parts = append(parts, value)
+		case title != "":
+			parts = append(parts, title)
+		}
+	}
+	return strings.Join(parts, " · ")
+}
+
+// plainTextSnippetCap caps the rendered length of file.plain_text bodies
+// so search tables don't blow up when a snippet contains a large file.
+const plainTextSnippetCap = 1024
+
+func renderFilesText(files []File) string {
+	if len(files) == 0 {
+		return ""
+	}
+	var rendered []string
+	for _, f := range files {
+		if r := renderFileText(f); r != "" {
+			rendered = append(rendered, r)
+		}
+	}
+	return strings.Join(rendered, "\n")
+}
+
+func renderFileText(f File) string {
+	var pieces []string
+	if f.InitialComment != nil {
+		if c := strings.TrimSpace(f.InitialComment.Comment); c != "" {
+			pieces = append(pieces, c)
+		}
+	}
+	if pt := strings.TrimSpace(f.PlainText); pt != "" {
+		pieces = append(pieces, capRunes(pt, plainTextSnippetCap))
+	}
+
+	if len(pieces) > 0 {
+		return strings.Join(pieces, "\n")
+	}
+
+	// Fallback label: title → name → id. A file with no textual content
+	// still appears as "file: <name>" so the message isn't silently
+	// invisible.
+	for _, label := range []string{f.Title, f.Name, f.ID} {
+		if label = strings.TrimSpace(label); label != "" {
+			return "file: " + label
+		}
+	}
+	return ""
+}
+
+// capRunes truncates s to at most n runes, appending an ellipsis marker
+// when truncation occurred. Rune-safe so multi-byte characters aren't
+// split mid-sequence.
+func capRunes(s string, n int) string {
+	if utf8.RuneCountInString(s) <= n {
+		return s
+	}
+	runes := []rune(s)
+	return string(runes[:n]) + "…"
+}

--- a/internal/client/message_render.go
+++ b/internal/client/message_render.go
@@ -82,13 +82,13 @@ func (a Attachment) MarshalJSON() ([]byte, error) {
 // content but Text isn't a duplicate of any individual rendered piece.
 func RenderMessage(c MessageContent, resolver MentionResolver) RenderedMessage {
 	pieces := make([]string, 0, 3)
-	if rendered := renderBlocksWithResolver(c.Blocks, resolver); rendered != "" {
+	if rendered := resolveMentions(renderBlocksWithResolver(c.Blocks, resolver), resolver); rendered != "" {
 		pieces = append(pieces, rendered)
 	}
-	if rendered := renderAttachments(c.Attachments, resolver); rendered != "" {
+	if rendered := resolveMentions(renderAttachments(c.Attachments, resolver), resolver); rendered != "" {
 		pieces = append(pieces, rendered)
 	}
-	if rendered := renderFilesText(c.Files); rendered != "" {
+	if rendered := resolveMentions(renderFilesText(c.Files), resolver); rendered != "" {
 		pieces = append(pieces, rendered)
 	}
 
@@ -133,6 +133,18 @@ func normalizeWhitespace(s string) string {
 	return strings.Join(strings.Fields(s), " ")
 }
 
+// resolveMentions runs s through the resolver's mention substitution if a
+// resolver is supplied. Rich-text user elements are resolved during their
+// own rendering, but plain-text section/attachment/file fields can still
+// carry raw `<@U…>` literals; this is the post-pass that catches them.
+// Safe with nil/empty.
+func resolveMentions(s string, resolver MentionResolver) string {
+	if s == "" || resolver == nil {
+		return s
+	}
+	return resolver.ResolveMentions(s)
+}
+
 // renderBlocksWithResolver bridges the MentionResolver interface to the
 // existing *UserResolver-typed RenderBlocks. nil resolver passes through.
 func renderBlocksWithResolver(blocks []Block, resolver MentionResolver) string {
@@ -161,15 +173,15 @@ func renderAttachments(atts []Attachment, resolver MentionResolver) string {
 
 func renderAttachment(a Attachment, resolver MentionResolver) string {
 	var pieces []string
-	addNonEmpty := func(s string) {
-		if s != "" {
-			pieces = append(pieces, s)
+	addTrimmed := func(s string) {
+		if t := strings.TrimSpace(s); t != "" {
+			pieces = append(pieces, t)
 		}
 	}
 
-	addNonEmpty(a.Pretext)
-	addNonEmpty(a.Title)
-	addNonEmpty(a.Text)
+	addTrimmed(a.Pretext)
+	addTrimmed(a.Title)
+	addTrimmed(a.Text)
 
 	if line := renderAttachmentFields(a.Fields); line != "" {
 		pieces = append(pieces, line)
@@ -179,7 +191,7 @@ func renderAttachment(a Attachment, resolver MentionResolver) string {
 		pieces = append(pieces, blocks)
 	}
 
-	addNonEmpty(a.Footer)
+	addTrimmed(a.Footer)
 
 	if len(pieces) == 0 {
 		// Fallback only when nothing else from the attachment rendered.

--- a/internal/client/message_render_test.go
+++ b/internal/client/message_render_test.go
@@ -259,6 +259,49 @@ func TestAttachment_JSONRoundTripPreservesUnknownFields(t *testing.T) {
 	assert.Contains(t, string(out), `"callback_id":"cb_42"`)
 }
 
+// fakeResolver is a non-*UserResolver implementation of MentionResolver
+// used to confirm the renderer's interface contract.
+type fakeResolver struct {
+	names map[string]string
+}
+
+func (f *fakeResolver) Resolve(userID string) string {
+	if name, ok := f.names[userID]; ok {
+		return name
+	}
+	return userID
+}
+
+func (f *fakeResolver) ResolveMentions(text string) string {
+	for id, name := range f.names {
+		text = strings.ReplaceAll(text, "<@"+id+">", "@"+name)
+	}
+	return text
+}
+
+// TestRenderMessage_NonUserResolverHonoredForPlainText confirms a
+// MentionResolver implementation that isn't *UserResolver still gets
+// invoked for plain-text surfaces (section/attachment/file). Rich-text
+// inline rendering is a known gap (deferred) — see the comment on
+// renderBlocksWithResolver.
+func TestRenderMessage_NonUserResolverHonoredForPlainText(t *testing.T) {
+	resolver := &fakeResolver{names: map[string]string{"U999": "alice"}}
+
+	blocks := mustBlocks(t, `[{
+		"type": "section",
+		"text": {"type": "mrkdwn", "text": "hi <@U999>"}
+	}]`)
+	got := RenderMessage(MessageContent{Blocks: blocks}, resolver)
+	assert.Equal(t, "hi @alice", got.Body)
+}
+
+func TestRenderMessage_NonUserResolverOnAttachmentText(t *testing.T) {
+	resolver := &fakeResolver{names: map[string]string{"U42": "bob"}}
+	atts := mustAttachments(t, `[{"text": "ping <@U42>"}]`)
+	got := RenderMessage(MessageContent{Attachments: atts}, resolver)
+	assert.Equal(t, "ping @bob", got.Body)
+}
+
 func TestNormalizeWhitespace(t *testing.T) {
 	assert.Equal(t, "a b c", normalizeWhitespace("  a   b\nc  "))
 	assert.Equal(t, "", normalizeWhitespace("   \t\n  "))

--- a/internal/client/message_render_test.go
+++ b/internal/client/message_render_test.go
@@ -202,6 +202,31 @@ func TestRenderAttachments_FieldsAndNestedBlocks(t *testing.T) {
 	assert.Equal(t, expected, got.Body)
 }
 
+func TestRenderAttachments_AuthorNameRendered(t *testing.T) {
+	atts := mustAttachments(t, `[{"author_name": "deploy-bot", "text": "shipped v1.2.3"}]`)
+	got := RenderMessage(MessageContent{Attachments: atts}, nil)
+	assert.Equal(t, "deploy-bot\nshipped v1.2.3", got.Body)
+}
+
+func TestRenderAttachments_AuthorNameOnlyAttachmentDoesNotFallThroughToFallback(t *testing.T) {
+	atts := mustAttachments(t, `[{"author_name": "ci-bot", "fallback": "ci-bot says..."}]`)
+	got := RenderMessage(MessageContent{Attachments: atts}, nil)
+	// AuthorName renders, fallback is suppressed.
+	assert.Equal(t, "ci-bot", got.Body)
+}
+
+func TestRenderMessage_MultiBlockJoinedTextIsDuplicate(t *testing.T) {
+	// Slack populates m.Text as the newline-joined rendering of multiple
+	// blocks for Block Kit fallback. The aggregate comparison catches
+	// that case so text isn't double-printed.
+	blocks := mustBlocks(t, `[
+		{"type":"section","text":{"type":"mrkdwn","text":"line1"}},
+		{"type":"section","text":{"type":"mrkdwn","text":"line2"}}
+	]`)
+	got := RenderMessage(MessageContent{Text: "line1\nline2", Blocks: blocks}, nil)
+	assert.Equal(t, "line1\nline2", got.Body)
+}
+
 func TestRenderAttachments_FallbackUsedOnlyWhenEmpty(t *testing.T) {
 	atts := mustAttachments(t, `[{"fallback": "plain text version"}]`)
 	got := RenderMessage(MessageContent{Attachments: atts}, nil)

--- a/internal/client/message_render_test.go
+++ b/internal/client/message_render_test.go
@@ -1,0 +1,266 @@
+package client
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func mustAttachments(t *testing.T, raw string) []Attachment {
+	t.Helper()
+	var atts []Attachment
+	require.NoError(t, json.Unmarshal([]byte(raw), &atts))
+	return atts
+}
+
+func TestRenderBlocks_Section(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "section",
+		"text": {"type": "mrkdwn", "text": "Served Rian in #general · 20.7s · claude-sonnet-4-6"}
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Equal(t, "Served Rian in #general · 20.7s · claude-sonnet-4-6", got)
+}
+
+func TestRenderBlocks_SectionFields(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "section",
+		"text": {"type": "mrkdwn", "text": "Status report"},
+		"fields": [
+			{"type": "mrkdwn", "text": "Cost: $0.07"},
+			{"type": "mrkdwn", "text": "Tokens: 73,746"}
+		]
+	}]`)
+	got := RenderBlocks(blocks, nil)
+	assert.Equal(t, "Status report\nCost: $0.07 · Tokens: 73,746", got)
+}
+
+func TestRenderBlocks_Header(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "header",
+		"text": {"type": "plain_text", "text": "Deploy Summary"}
+	}]`)
+	assert.Equal(t, "Deploy Summary", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_Context(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "context",
+		"elements": [
+			{"type": "image", "image_url": "x", "alt_text": "logo"},
+			{"type": "mrkdwn", "text": "v1.2.3"}
+		]
+	}]`)
+	assert.Equal(t, "logo v1.2.3", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_Actions(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "actions",
+		"elements": [
+			{"type": "button", "text": {"type": "plain_text", "text": "Approve"}},
+			{"type": "button", "text": {"type": "plain_text", "text": "Reject"}}
+		]
+	}]`)
+	assert.Equal(t, "[Approve] [Reject]", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_ImageWithAltText(t *testing.T) {
+	blocks := mustBlocks(t, `[{"type": "image", "alt_text": "graph of latency", "image_url": "x"}]`)
+	assert.Equal(t, "graph of latency", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_ImageWithoutAltOrTitle(t *testing.T) {
+	blocks := mustBlocks(t, `[{"type": "image", "image_url": "x"}]`)
+	assert.Equal(t, "", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_VideoTitleAndDescription(t *testing.T) {
+	blocks := mustBlocks(t, `[{
+		"type": "video",
+		"title": {"type": "plain_text", "text": "Demo"},
+		"description": {"type": "plain_text", "text": "release walkthrough"}
+	}]`)
+	assert.Equal(t, "Demo\nrelease walkthrough", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_DividerDropped(t *testing.T) {
+	blocks := mustBlocks(t, `[
+		{"type": "divider"},
+		{"type": "section", "text": {"type": "mrkdwn", "text": "after"}}
+	]`)
+	assert.Equal(t, "after", RenderBlocks(blocks, nil))
+}
+
+func TestRenderBlocks_BugRepro(t *testing.T) {
+	// Original bug shape from #143: a single section block carries the
+	// status line and m.Text is empty.
+	blocks := mustBlocks(t, `[{
+		"type": "section",
+		"text": {"type": "mrkdwn", "text": "Served Rian in #general · 20.7s · claude-sonnet-4-6 · 2 in (73,746 cached) · 77 out · $0.07"}
+	}]`)
+	got := RenderMessage(MessageContent{Blocks: blocks}, nil)
+	assert.Equal(t, "Served Rian in #general · 20.7s · claude-sonnet-4-6 · 2 in (73,746 cached) · 77 out · $0.07", got.Body)
+	assert.True(t, got.PreserveNewlines)
+}
+
+func TestRenderMessage_FallsBackToText(t *testing.T) {
+	got := RenderMessage(MessageContent{Text: "hi <@U123>"}, nil)
+	assert.Equal(t, "hi <@U123>", got.Body)
+	assert.False(t, got.PreserveNewlines)
+}
+
+func TestRenderMessage_EmptyEverywhere(t *testing.T) {
+	got := RenderMessage(MessageContent{}, nil)
+	assert.Equal(t, "", got.Body)
+	assert.False(t, got.PreserveNewlines)
+}
+
+func TestRenderMessage_MultiSurfaceCombined(t *testing.T) {
+	blocks := mustBlocks(t, `[{"type":"section","text":{"type":"mrkdwn","text":"block content"}}]`)
+	atts := mustAttachments(t, `[{"text":"attachment content"}]`)
+	files := []File{{InitialComment: &FileComment{Comment: "file commentary"}}}
+	got := RenderMessage(MessageContent{
+		Text:        "fallback",
+		Blocks:      blocks,
+		Attachments: atts,
+		Files:       files,
+	}, nil)
+	// text != any single piece, so it gets prepended.
+	assert.Equal(t, "fallback\nblock content\nattachment content\nfile commentary", got.Body)
+	assert.True(t, got.PreserveNewlines)
+}
+
+func TestRenderMessage_TextDuplicatesBlocksDropped(t *testing.T) {
+	blocks := mustBlocks(t, `[{"type":"section","text":{"type":"mrkdwn","text":"hello world"}}]`)
+	got := RenderMessage(MessageContent{Text: "hello world", Blocks: blocks}, nil)
+	assert.Equal(t, "hello world", got.Body)
+	assert.True(t, got.PreserveNewlines)
+}
+
+func TestRenderMessage_TextDuplicatesOnlyOnePieceStillDropped(t *testing.T) {
+	// text == blocks rendering exactly. Even though attachments add more
+	// content, the text shouldn't be double-printed because it duplicates
+	// one piece.
+	blocks := mustBlocks(t, `[{"type":"section","text":{"type":"mrkdwn","text":"hello"}}]`)
+	atts := mustAttachments(t, `[{"text":"more content"}]`)
+	got := RenderMessage(MessageContent{Text: "hello", Blocks: blocks, Attachments: atts}, nil)
+	assert.Equal(t, "hello\nmore content", got.Body)
+	assert.True(t, got.PreserveNewlines)
+}
+
+func TestRenderMessage_TextWhitespaceNormalizedDup(t *testing.T) {
+	blocks := mustBlocks(t, `[{"type":"section","text":{"type":"mrkdwn","text":"hello   world"}}]`)
+	got := RenderMessage(MessageContent{Text: "hello world", Blocks: blocks}, nil)
+	// Whitespace-normalized comparison treats "hello   world" == "hello world".
+	assert.Equal(t, "hello   world", got.Body)
+}
+
+func TestRenderMessage_NilResolverPreservesRawMentions(t *testing.T) {
+	got := RenderMessage(MessageContent{Text: "ping <@U123>"}, nil)
+	assert.Equal(t, "ping <@U123>", got.Body)
+}
+
+func TestRenderMessage_NilResolverInBlocks(t *testing.T) {
+	// Rich-text user element without resolver renders "@U123" (matches the
+	// existing nil-safe behavior in renderInline).
+	blocks := mustBlocks(t, `[{
+		"type": "rich_text",
+		"elements": [{"type":"rich_text_section","elements":[
+			{"type":"text","text":"hi "},
+			{"type":"user","user_id":"U123"}
+		]}]
+	}]`)
+	got := RenderMessage(MessageContent{Blocks: blocks}, nil)
+	assert.Equal(t, "hi @U123", got.Body)
+}
+
+func TestRenderAttachments_FieldsAndNestedBlocks(t *testing.T) {
+	atts := mustAttachments(t, `[{
+		"pretext": "Heads up",
+		"title": "Build #42",
+		"text": "Failed in 12s",
+		"fields": [
+			{"title": "Branch", "value": "main"},
+			{"title": "Commit", "value": "abc123"}
+		],
+		"blocks": [{"type":"section","text":{"type":"mrkdwn","text":"nested block"}}],
+		"footer": "CI"
+	}]`)
+	got := RenderMessage(MessageContent{Attachments: atts}, nil)
+	expected := strings.Join([]string{
+		"Heads up",
+		"Build #42",
+		"Failed in 12s",
+		"Branch: main · Commit: abc123",
+		"nested block",
+		"CI",
+	}, "\n")
+	assert.Equal(t, expected, got.Body)
+}
+
+func TestRenderAttachments_FallbackUsedOnlyWhenEmpty(t *testing.T) {
+	atts := mustAttachments(t, `[{"fallback": "plain text version"}]`)
+	got := RenderMessage(MessageContent{Attachments: atts}, nil)
+	assert.Equal(t, "plain text version", got.Body)
+}
+
+func TestRenderAttachments_FallbackSuppressedWhenOtherFieldsRender(t *testing.T) {
+	atts := mustAttachments(t, `[{
+		"text": "real content",
+		"fallback": "real content (legacy fallback)"
+	}]`)
+	got := RenderMessage(MessageContent{Attachments: atts}, nil)
+	// Fallback is dropped because text rendered.
+	assert.Equal(t, "real content", got.Body)
+}
+
+func TestRenderFilesText_InitialCommentAndPlainText(t *testing.T) {
+	files := []File{{
+		InitialComment: &FileComment{Comment: "see snippet"},
+		PlainText:      "package main\n\nfunc main() {}",
+		Title:          "main.go",
+		Name:           "main.go",
+	}}
+	got := RenderMessage(MessageContent{Files: files}, nil)
+	assert.Equal(t, "see snippet\npackage main\n\nfunc main() {}", got.Body)
+}
+
+func TestRenderFilesText_PlainTextCapped(t *testing.T) {
+	big := strings.Repeat("a", plainTextSnippetCap+500)
+	files := []File{{PlainText: big}}
+	got := RenderMessage(MessageContent{Files: files}, nil)
+	// Capped at plainTextSnippetCap runes plus the ellipsis marker.
+	assert.True(t, strings.HasSuffix(got.Body, "…"))
+	assert.LessOrEqual(t, len([]rune(got.Body)), plainTextSnippetCap+1)
+}
+
+func TestRenderFilesText_LabelFallback(t *testing.T) {
+	files := []File{{Title: "report.pdf", ID: "F123"}}
+	got := RenderMessage(MessageContent{Files: files}, nil)
+	assert.Equal(t, "file: report.pdf", got.Body)
+}
+
+func TestAttachment_JSONRoundTripPreservesUnknownFields(t *testing.T) {
+	// Attachment with fields outside the typed struct (color, mrkdwn_in,
+	// callback_id) must round-trip byte-identically at those keys so
+	// --output json stays unchanged.
+	original := `{"text":"hi","color":"#36a64f","mrkdwn_in":["text"],"callback_id":"cb_42"}`
+	var a Attachment
+	require.NoError(t, json.Unmarshal([]byte(original), &a))
+
+	out, err := json.Marshal(a)
+	require.NoError(t, err)
+	assert.JSONEq(t, original, string(out))
+	assert.Contains(t, string(out), `"color":"#36a64f"`)
+	assert.Contains(t, string(out), `"callback_id":"cb_42"`)
+}
+
+func TestNormalizeWhitespace(t *testing.T) {
+	assert.Equal(t, "a b c", normalizeWhitespace("  a   b\nc  "))
+	assert.Equal(t, "", normalizeWhitespace("   \t\n  "))
+	assert.Equal(t, "", normalizeWhitespace(""))
+}

--- a/internal/client/message_render_test.go
+++ b/internal/client/message_render_test.go
@@ -246,8 +246,8 @@ func TestRenderFilesText_LabelFallback(t *testing.T) {
 
 func TestAttachment_JSONRoundTripPreservesUnknownFields(t *testing.T) {
 	// Attachment with fields outside the typed struct (color, mrkdwn_in,
-	// callback_id) must round-trip byte-identically at those keys so
-	// --output json stays unchanged.
+	// callback_id) must round-trip losslessly so --output json preserves
+	// unknown fields the typed struct doesn't model.
 	original := `{"text":"hi","color":"#36a64f","mrkdwn_in":["text"],"callback_id":"cb_42"}`
 	var a Attachment
 	require.NoError(t, json.Unmarshal([]byte(original), &a))

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -63,16 +63,19 @@ func truncate(s string, maxLen int) string {
 	return s[:maxLen-3] + "..."
 }
 
-// messageBody chooses the right source for a message's textual content.
-// When blocks render non-empty, returns the rendered body with
-// fromBlocks=true; otherwise returns the mention-resolved m.Text with
-// fromBlocks=false. Callers use fromBlocks to decide whether to preserve
-// newlines (thread detail view) or flatten them (text-only path).
-func messageBody(m client.Message, resolver *client.UserResolver) (body string, fromBlocks bool) {
-	if rendered := client.RenderBlocks(m.Blocks, resolver); rendered != "" {
-		return rendered, true
-	}
-	return resolver.ResolveMentions(m.Text), false
+// messageBody renders a message's readable surfaces (text, blocks,
+// attachments, files) into a single body string via the shared renderer.
+// preserveNewlines is true when the body came from a richer surface;
+// callers that flatten plain-text in compact views should leave such
+// content alone.
+func messageBody(m client.Message, resolver *client.UserResolver) (body string, preserveNewlines bool) {
+	rendered := client.RenderMessage(client.MessageContent{
+		Text:        m.Text,
+		Blocks:      m.Blocks,
+		Attachments: m.Attachments,
+		Files:       m.Files,
+	}, resolver)
+	return rendered.Body, rendered.PreserveNewlines
 }
 
 // indentContinuation replaces interior newlines with "\n\t" so that every

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1913,7 +1913,10 @@ func TestRunThread_RendersRichTextBlocks(t *testing.T) {
 	assert.Contains(t, out, "Account Number Check Number")
 }
 
-func TestRunThread_BlocksOverrideNonEmptyText(t *testing.T) {
+func TestRunThread_TextDuplicatingBlocksIsDropped(t *testing.T) {
+	// When m.Text exactly matches the blocks rendering (Slack's plain-text
+	// fallback for Block Kit messages), the duplicate is suppressed —
+	// only the rendered blocks appear.
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/conversations.replies":
@@ -1923,7 +1926,7 @@ func TestRunThread_BlocksOverrideNonEmptyText(t *testing.T) {
 					{
 						"ts":   "1234567890.123456",
 						"user": "U001",
-						"text": "FALLBACK_TEXT_SENTINEL",
+						"text": "FROM_BLOCKS",
 						"blocks": []map[string]interface{}{
 							{
 								"type": "rich_text",
@@ -1953,7 +1956,8 @@ func TestRunThread_BlocksOverrideNonEmptyText(t *testing.T) {
 		require.NoError(t, runThread("C123", "1234567890.123456", opts, c))
 	})
 	assert.Contains(t, out, "FROM_BLOCKS")
-	assert.NotContains(t, out, "FALLBACK_TEXT_SENTINEL")
+	// Duplicate suppression: text shouldn't appear twice in the output.
+	assert.Equal(t, 1, strings.Count(out, "FROM_BLOCKS"))
 }
 
 func TestRunThread_FallsBackToTextWhenSubBlocksUnrenderable(t *testing.T) {

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -2067,6 +2067,109 @@ func TestRunThread_FallsBackToTextWhenBlocksNil(t *testing.T) {
 	assert.Contains(t, out, "plain old text")
 }
 
+// TestRunHistory_AttachmentTextRendersInOutput exercises the
+// attachments path through the command layer — search/history/thread all
+// share the same RenderMessage call site.
+func TestRunHistory_AttachmentTextRendersInOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.history":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{{
+					"ts":   "1234567890.123456",
+					"user": "U001",
+					"text": "",
+					"attachments": []map[string]interface{}{{
+						"title": "Build #42",
+						"text":  "Failed in 12s",
+						"fields": []map[string]interface{}{
+							{"title": "Branch", "value": "main"},
+						},
+					}},
+				}},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runHistory("C123", &historyOptions{limit: 20}, c))
+	})
+	// Attachment title + text both flow through (history truncates to 80
+	// and joins newlines into spaces, so we look for both substrings).
+	assert.Contains(t, out, "Build #42")
+}
+
+// TestRunThread_FileInitialCommentRendersInBody verifies file
+// initial_comment text reaches the body via RenderMessage. The legacy
+// "[file] X — slck files download Y" hint line is rendered separately
+// by renderFiles and is unaffected by this path.
+func TestRunThread_FileInitialCommentRendersInBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{{
+					"ts":   "1234567890.123456",
+					"user": "U001",
+					"text": "",
+					"files": []map[string]interface{}{{
+						"id":              "F1",
+						"name":            "report.pdf",
+						"initial_comment": map[string]interface{}{"comment": "see snippet"},
+					}},
+				}},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", &threadOptions{limit: 100}, c))
+	})
+	assert.Contains(t, out, "see snippet")
+}
+
+// TestRunThread_SectionBlockRendersInBody is the symmetric coverage for
+// thread (history is covered separately) — confirms section blocks
+// render through the thread command path.
+func TestRunThread_SectionBlockRendersInBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.replies":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{{
+					"ts":   "1234567890.123456",
+					"user": "U001",
+					"text": "",
+					"blocks": []map[string]interface{}{{
+						"type": "section",
+						"text": map[string]interface{}{"type": "mrkdwn", "text": "section in thread"},
+					}},
+				}},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runThread("C123", "1234567890.123456", &threadOptions{limit: 100}, c))
+	})
+	assert.Contains(t, out, "section in thread")
+}
+
 // TestRunHistory_SectionBlockRendersInTextColumn is the messages-side
 // regression for issue #143: a non-rich_text section block must surface
 // its text in the rendered output, not just in --output json.

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -2067,6 +2067,44 @@ func TestRunThread_FallsBackToTextWhenBlocksNil(t *testing.T) {
 	assert.Contains(t, out, "plain old text")
 }
 
+// TestRunHistory_SectionBlockRendersInTextColumn is the messages-side
+// regression for issue #143: a non-rich_text section block must surface
+// its text in the rendered output, not just in --output json.
+func TestRunHistory_SectionBlockRendersInTextColumn(t *testing.T) {
+	statusLine := "Served Rian in #general · claude-sonnet-4-6"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/conversations.history":
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{
+						"ts":   "1234567890.123456",
+						"user": "U001",
+						"text": "",
+						"blocks": []map[string]interface{}{
+							{
+								"type": "section",
+								"text": map[string]interface{}{"type": "mrkdwn", "text": statusLine},
+							},
+						},
+					},
+				},
+			})
+		case "/users.info":
+			mockUserInfoHandler(w, r)
+		}
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	opts := &historyOptions{limit: 20}
+	out := captureTextOutput(t, func() {
+		require.NoError(t, runHistory("C123", opts, c))
+	})
+	assert.Contains(t, out, "Served Rian in #general")
+}
+
 func TestRunThread_MultilineBlocksIndentContinuationLines(t *testing.T) {
 	// A rich_text block with two sections renders as two lines; the
 	// second line must be indented with \t under the header.

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -68,11 +68,12 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 	resolver := client.NewUserResolver(c)
 	for _, m := range messages {
 		ts := formatTimestamp(m.TS)
-		body, fromBlocks := messageBody(m, resolver)
+		body, preserveNewlines := messageBody(m, resolver)
 		var text string
-		if fromBlocks {
-			// Preserve newlines from rendered blocks; indent continuation
-			// lines so multi-line content stays visually grouped.
+		if preserveNewlines {
+			// Body came from a richer surface (blocks/attachments/files);
+			// indent continuation lines so multi-line content stays
+			// visually grouped under the [ts] user: header.
 			text = indentContinuation(body)
 		} else {
 			// Plain-text fallback keeps existing single-line behavior.

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -125,7 +125,13 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 		headers := []string{"CHANNEL", "USER", "TIMESTAMP", "TEXT"}
 		rows := make([][]string, 0, len(result.Messages.Matches))
 		for _, m := range result.Messages.Matches {
-			text := truncateText(m.Text, 60)
+			body := client.RenderMessage(client.MessageContent{
+				Text:        m.Text,
+				Blocks:      m.Blocks,
+				Attachments: m.Attachments,
+				Files:       m.Files,
+			}, nil).Body
+			text := truncateText(body, 60)
 			ts := formatTimestamp(m.TS)
 			rows = append(rows, []string{m.Channel.Name, m.Username, ts, text})
 		}

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -129,7 +129,13 @@ func runSearchMessages(query string, opts *messagesOptions, c *client.Client) er
 	headers := []string{"CHANNEL", "USER", "TIMESTAMP", "TEXT"}
 	rows := make([][]string, 0, len(result.Messages.Matches))
 	for _, m := range result.Messages.Matches {
-		text := truncateText(m.Text, 60)
+		body := client.RenderMessage(client.MessageContent{
+			Text:        m.Text,
+			Blocks:      m.Blocks,
+			Attachments: m.Attachments,
+			Files:       m.Files,
+		}, nil).Body
+		text := truncateText(body, 60)
 		ts := formatTimestamp(m.TS)
 		rows = append(rows, []string{m.Channel.Name, m.Username, ts, text})
 	}

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -4,9 +4,11 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 // Helper to create a test client with a mock server
@@ -543,6 +545,100 @@ func TestTruncateText(t *testing.T) {
 				t.Errorf("truncateText() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+// captureOutput swaps output.Writer for a buffer and returns its contents.
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	orig := output.Writer
+	output.Writer = &buf
+	defer func() { output.Writer = orig }()
+	fn()
+	return buf.String()
+}
+
+// TestRunSearchMessages_RendersBlocksTextInTable is the regression test
+// for issue #143: a search match whose content lives in a section block
+// must appear in the rendered table column rather than showing empty.
+func TestRunSearchMessages_RendersBlocksTextInTable(t *testing.T) {
+	statusLine := "Served Rian in #general · 20.7s · claude-sonnet-4-6 · 2 in (73,746 cached) · 77 out · $0.07"
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"type":      "message",
+				"channel":   map[string]interface{}{"id": "C123", "name": "general"},
+				"user":      "U123",
+				"username":  "claude-bot",
+				"text":      "",
+				"ts":        "1704067200.000000",
+				"permalink": "https://slack.com/archives/C123/p1704067200000000",
+				"blocks": []map[string]interface{}{{
+					"type": "section",
+					"text": map[string]interface{}{"type": "mrkdwn", "text": statusLine},
+				}},
+			}},
+		},
+	}
+
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	opts := &messagesOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}
+	out := captureOutput(t, func() {
+		if err := runSearchMessages("claude-sonnet", opts, c); err != nil {
+			t.Fatalf("runSearchMessages: %v", err)
+		}
+	})
+	// Truncated to 60 chars in the table — assert the prefix is present.
+	if !strings.Contains(out, "Served Rian in #general") {
+		t.Errorf("expected section-block text in table output; got:\n%s", out)
+	}
+}
+
+// TestRunSearchAll_RendersBlocksTextInTable verifies the same shared
+// renderer is wired into search all (same call-site bug existed there).
+func TestRunSearchAll_RendersBlocksTextInTable(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"type":      "message",
+				"channel":   map[string]interface{}{"id": "C1", "name": "general"},
+				"user":      "U1",
+				"username":  "alice",
+				"text":      "",
+				"ts":        "1704067200.000000",
+				"permalink": "https://slack.com/archives/C1/p1",
+				"blocks": []map[string]interface{}{{
+					"type": "section",
+					"text": map[string]interface{}{"type": "mrkdwn", "text": "block-only content"},
+				}},
+			}},
+		},
+	}
+
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	opts := &allOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}
+	out := captureOutput(t, func() {
+		if err := runSearchAll("query", opts, c); err != nil {
+			t.Fatalf("runSearchAll: %v", err)
+		}
+	})
+	if !strings.Contains(out, "block-only content") {
+		t.Errorf("expected section-block text in search-all output; got:\n%s", out)
 	}
 }
 

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -642,6 +642,50 @@ func TestRunSearchAll_RendersBlocksTextInTable(t *testing.T) {
 	}
 }
 
+// TestRunSearchMessages_AttachmentAndFileFlow proves the command also
+// surfaces text from legacy attachments and file initial_comment through
+// the shared renderer — not just blocks.
+func TestRunSearchMessages_AttachmentAndFileFlow(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"type":      "message",
+				"channel":   map[string]interface{}{"id": "C1", "name": "alerts"},
+				"user":      "U1",
+				"username":  "ci-bot",
+				"text":      "",
+				"ts":        "1704067200.000000",
+				"permalink": "https://slack.com/archives/C1/p1",
+				"attachments": []map[string]interface{}{{
+					"title": "Deploy v1.2.3",
+				}},
+				"files": []map[string]interface{}{{
+					"id":              "F1",
+					"name":            "log.txt",
+					"initial_comment": map[string]interface{}{"comment": "release notes attached"},
+				}},
+			}},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		if err := runSearchMessages("deploy", &messagesOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchMessages: %v", err)
+		}
+	})
+	// Truncation to 60 chars still leaves the leading attachment title visible.
+	if !strings.Contains(out, "Deploy v1.2.3") {
+		t.Errorf("expected attachment text in search output; got:\n%s", out)
+	}
+}
+
 func TestFormatTimestamp(t *testing.T) {
 	tests := []struct {
 		name  string


### PR DESCRIPTION
## Summary

- Adds a shared `client.RenderMessage` that walks all readable Slack surfaces (text, blocks, attachments, files) and is used by `search messages`, `search all`, `messages history`, and `messages thread`.
- Extends `RenderBlocks` beyond `rich_text` to `section`, `header`, `context`, `actions`, `image`, and `video`. `divider`/unknown drop. Block JSON round-trip preserved via raw bytes.
- Adds `Attachment` model with the same raw-bytes round-trip strategy so `--output json` is byte-stable on unmodeled fields (`color`, `mrkdwn_in`, `callback_id`, etc.).
- Files render `initial_comment` + capped `plain_text`, with a `file: <name>` label fallback.
- Top-level `text` suppression uses whitespace-normalized per-piece equality so the Block-Kit-fallback double-print case is caught while genuine non-duplicate fallback text is preserved.

## Tests

- New renderer tests in `internal/client/message_render_test.go` covering section + fields, header, context, actions buttons, image alt-text, video title/description, divider drop, attachment fields + nested blocks recursion, attachment `fallback` only-when-empty, file `initial_comment` + `plain_text`, file plain-text cap, file label fallback, attachment JSON round-trip preserving unknown fields, multi-surface combination, duplicate detection (per-piece), whitespace-normalized duplicate, nil-resolver behavior, the original bug's repro shape.
- Extended `internal/client/blocks_test.go` coverage for the new block types.
- New `internal/cmd/search/search_test.go` tests assert section-block content surfaces in the rendered table for both `search messages` and `search all`.
- Existing thread test renamed/updated to reflect the new duplicate-suppression semantic (text matching blocks rendering shows once, not twice).

## Tier 3 follow-ups (deferred)

Per ticket: highlight integration, `metadata.event_payload` surfacing, and search-index gap docs all depend on empirical experiments that aren't part of this fix. Tracked as a follow-up.

## Test plan

- [x] `go test ./...` — 653 passed in 18 packages
- [x] `make lint` — 0 issues
- [x] Manual: `slck search messages` against a real workspace returns rendered section-block text in the table column.