### PR TITLE
feat(messages): add message refs and read command for search-to-read workflow

### DIFF
--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -25,6 +25,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(newDeleteCmd())
 	cmd.AddCommand(newHistoryCmd())
 	cmd.AddCommand(newThreadCmd())
+	cmd.AddCommand(newReadCmd())
 	cmd.AddCommand(newReactCmd())
 	cmd.AddCommand(newUnreactCmd())
 

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -2572,6 +2572,7 @@ func TestRunRead_Success(t *testing.T) {
 		if r.URL.Path == "/conversations.replies" {
 			assert.Equal(t, "C02DF3BEUGN", r.URL.Query().Get("channel"))
 			assert.Equal(t, "1777469221.721439", r.URL.Query().Get("ts"))
+			assert.Equal(t, "42", r.URL.Query().Get("limit"))
 			_ = json.NewEncoder(w).Encode(map[string]interface{}{
 				"ok": true,
 				"messages": []map[string]interface{}{
@@ -2592,7 +2593,7 @@ func TestRunRead_Success(t *testing.T) {
 	output.Writer = &buf
 	defer func() { output.Writer = orig }()
 
-	err := runRead("C02DF3BEUGN/1777469221.721439", &readOptions{limit: 100}, c)
+	err := runRead("C02DF3BEUGN/1777469221.721439", &readOptions{limit: 42}, c)
 	require.NoError(t, err)
 	out := buf.String()
 	assert.Contains(t, out, "parent body")

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -2677,3 +2677,19 @@ func TestRunRead_JSONOutput(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf.String(), `"text": "hi"`)
 }
+
+func TestRunRead_EmptyMessages(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "messages": []map[string]interface{}{}})
+	}))
+	defer server.Close()
+	c := client.NewWithConfig(server.URL, "tok", nil)
+	var buf strings.Builder
+	orig := output.Writer
+	output.Writer = &buf
+	defer func() { output.Writer = orig }()
+
+	err := runRead("C02DF3BEUGN/1777469221.721439", &readOptions{limit: 100}, c)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), "No messages found")
+}

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -2566,3 +2566,113 @@ func TestRunHistory_TextIncludesFileHints(t *testing.T) {
 	assert.Contains(t, out, "\t[file] IW Trailer.pdf (pdf, 59.2 KB) — slck files download F0ATD4WJ70D\n")
 	assert.NotContains(t, out, "...F0ATD4WJ70D")
 }
+
+func TestRunRead_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/conversations.replies" {
+			assert.Equal(t, "C02DF3BEUGN", r.URL.Query().Get("channel"))
+			assert.Equal(t, "1777469221.721439", r.URL.Query().Get("ts"))
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok": true,
+				"messages": []map[string]interface{}{
+					{"type": "message", "user": "U1", "text": "parent body", "ts": "1777469221.721439"},
+					{"type": "message", "user": "U2", "text": "first reply", "ts": "1777469300.000000"},
+				},
+			})
+			return
+		}
+		// User resolver lookups — return a minimal valid response.
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "user": map[string]interface{}{"id": "U?", "name": "u"}})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	var buf strings.Builder
+	orig := output.Writer
+	output.Writer = &buf
+	defer func() { output.Writer = orig }()
+
+	err := runRead("C02DF3BEUGN/1777469221.721439", &readOptions{limit: 100}, c)
+	require.NoError(t, err)
+	out := buf.String()
+	assert.Contains(t, out, "parent body")
+	assert.Contains(t, out, "first reply")
+}
+
+func TestRunRead_AcceptsPermalink(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/conversations.replies" {
+			assert.Equal(t, "C02DF3BEUGN", r.URL.Query().Get("channel"))
+			assert.Equal(t, "1777469221.721439", r.URL.Query().Get("ts"))
+			_ = json.NewEncoder(w).Encode(map[string]interface{}{
+				"ok":       true,
+				"messages": []map[string]interface{}{{"type": "message", "user": "U1", "text": "hi", "ts": "1777469221.721439"}},
+			})
+			return
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": true, "user": map[string]interface{}{"id": "U?", "name": "u"}})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	var buf strings.Builder
+	orig := output.Writer
+	output.Writer = &buf
+	defer func() { output.Writer = orig }()
+
+	err := runRead("https://example.slack.com/archives/C02DF3BEUGN/p1777469221721439", &readOptions{limit: 100}, c)
+	require.NoError(t, err)
+}
+
+func TestRunRead_NotInChannelHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": "not_in_channel"})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	err := runRead("C02DF3BEUGN/1777469221.721439", &readOptions{limit: 100}, c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "slck --as-user messages read")
+	assert.Contains(t, err.Error(), "C02DF3BEUGN/1777469221.721439")
+}
+
+func TestRunRead_InvalidRef(t *testing.T) {
+	err := runRead("not-a-ref", &readOptions{limit: 100}, nil)
+	require.Error(t, err)
+}
+
+func TestRunRead_OtherErrorNoHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": "ratelimited"})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	err := runRead("C02DF3BEUGN/1777469221.721439", &readOptions{limit: 100}, c)
+	require.Error(t, err)
+	assert.NotContains(t, err.Error(), "--as-user")
+}
+
+func TestRunRead_JSONOutput(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":       true,
+			"messages": []map[string]interface{}{{"type": "message", "user": "U1", "text": "hi", "ts": "1777469221.721439"}},
+		})
+	}))
+	defer server.Close()
+
+	c := client.NewWithConfig(server.URL, "test-token", nil)
+	var buf strings.Builder
+	orig := output.Writer
+	output.Writer = &buf
+	defer func() { output.Writer = orig }()
+	origFmt := output.OutputFormat
+	output.OutputFormat = output.FormatJSON
+	defer func() { output.OutputFormat = origFmt }()
+
+	err := runRead("C02DF3BEUGN/1777469221.721439", &readOptions{limit: 100}, c)
+	require.NoError(t, err)
+	assert.Contains(t, buf.String(), `"text": "hi"`)
+}

--- a/internal/cmd/messages/read.go
+++ b/internal/cmd/messages/read.go
@@ -1,0 +1,81 @@
+package messages
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/messageref"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+type readOptions struct {
+	limit int
+}
+
+func newReadCmd() *cobra.Command {
+	opts := &readOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "read <message-ref>",
+		Short: "Read a message thread by ref",
+		Long: `Read the conversation thread for a message ref.
+
+A message ref is the composite identity for a message in a channel:
+  <channel_id>/<ts>           e.g. C02DF3BEUGN/1777469221.721439
+  Slack permalink             e.g. https://workspace.slack.com/archives/C02DF3BEUGN/p1777469221721439
+
+Refs are emitted as the REF column by 'slck search messages' and 'slck search all'.
+
+Returns whatever Slack's conversations.replies returns for the ref. When the ref
+points at a thread parent, that's the parent plus all replies. Some channels
+require user-token semantics; pair with --as-user when search returned the ref.
+
+Examples:
+  slck messages read C02DF3BEUGN/1777469221.721439
+  slck --as-user messages read C02DF3BEUGN/1777469221.721439`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRead(args[0], opts, nil)
+		},
+	}
+
+	cmd.Flags().IntVar(&opts.limit, "limit", 100, "Maximum messages to return")
+
+	return cmd
+}
+
+func runRead(input string, opts *readOptions, c *client.Client) error {
+	ref, err := messageref.Parse(input)
+	if err != nil {
+		return err
+	}
+
+	if c == nil {
+		c, err = client.New()
+		if err != nil {
+			return err
+		}
+	}
+
+	messages, err := c.GetThreadReplies(ref.ChannelID, ref.TS, opts.limit, "")
+	if err != nil {
+		if client.IsSlackError(err, "not_in_channel") {
+			return fmt.Errorf("%w\nHint: try `slck --as-user messages read %s` — search-derived refs typically require user-token access", err, ref)
+		}
+		return err
+	}
+
+	if output.IsJSON() {
+		return output.PrintJSON(messages)
+	}
+
+	if len(messages) == 0 {
+		output.Println("No messages found for ref")
+		return nil
+	}
+
+	renderMessageList(messages, client.NewUserResolver(c))
+	return nil
+}

--- a/internal/cmd/messages/read.go
+++ b/internal/cmd/messages/read.go
@@ -62,7 +62,7 @@ func runRead(input string, opts *readOptions, c *client.Client) error {
 	messages, err := c.GetThreadReplies(ref.ChannelID, ref.TS, opts.limit, "")
 	if err != nil {
 		if client.IsSlackError(err, "not_in_channel") {
-			return fmt.Errorf("%w\nHint: try `slck --as-user messages read %s` — search-derived refs typically require user-token access", err, ref)
+			return fmt.Errorf("%w; try `slck --as-user messages read %s` — search-derived refs typically require user-token access", err, ref)
 		}
 		return err
 	}

--- a/internal/cmd/messages/thread.go
+++ b/internal/cmd/messages/thread.go
@@ -65,18 +65,21 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 		return nil
 	}
 
-	resolver := client.NewUserResolver(c)
+	renderMessageList(messages, client.NewUserResolver(c))
+	return nil
+}
+
+// renderMessageList prints "[ts] user: body" lines for each message, with
+// continuation indentation for multi-line bodies, edited markers, and file
+// attachment lines. Shared between `messages thread` and `messages read`.
+func renderMessageList(messages []client.Message, resolver *client.UserResolver) {
 	for _, m := range messages {
 		ts := formatTimestamp(m.TS)
 		body, preserveNewlines := messageBody(m, resolver)
 		var text string
 		if preserveNewlines {
-			// Body came from a richer surface (blocks/attachments/files);
-			// indent continuation lines so multi-line content stays
-			// visually grouped under the [ts] user: header.
 			text = indentContinuation(body)
 		} else {
-			// Plain-text fallback keeps existing single-line behavior.
 			text = flatten(body)
 		}
 		name := resolver.Resolve(m.User)
@@ -84,9 +87,6 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 		if m.Edited != nil {
 			edited = " [edited]"
 		}
-		// For multi-line bodies, place [edited] on the first line so it
-		// annotates the whole message rather than appearing to annotate
-		// only the final continuation line.
 		if edited != "" {
 			if idx := strings.Index(text, "\n"); idx >= 0 {
 				text = text[:idx] + edited + text[idx:]
@@ -98,6 +98,4 @@ func runThread(channel, threadTS string, opts *threadOptions, c *client.Client) 
 			output.Printf("%s", files)
 		}
 	}
-
-	return nil
 }

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -141,6 +141,7 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 		paging := result.Messages.Paging
 		output.Printf("\nPage %d of %d (showing %d of %d messages)\n",
 			paging.Page, paging.Pages, len(result.Messages.Matches), paging.Total)
+		output.Println("Read: slck --as-user messages read <REF>")
 	}
 
 	// Add spacing between sections
@@ -165,10 +166,6 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 		paging := result.Files.Paging
 		output.Printf("\nPage %d of %d (showing %d of %d files)\n",
 			paging.Page, paging.Pages, len(result.Files.Matches), paging.Total)
-	}
-
-	if hasMessages {
-		output.Println("\nRead: slck --as-user messages read <REF>")
 	}
 
 	return nil

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -4,6 +4,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/messageref"
 	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
@@ -132,7 +133,7 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 				Files:       m.Files,
 			}, nil).Body
 			when := formatTimestamp(m.TS)
-			ref := m.Channel.ID + "/" + m.TS
+			ref := messageref.Ref{ChannelID: m.Channel.ID, TS: m.TS}.String()
 			rows = append(rows, []string{ref, m.Channel.Name, m.Username, when, body})
 		}
 		output.SearchTable(headers, rows, 60)

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -122,7 +122,7 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 	if hasMessages {
 		output.Printf("=== Messages (%d total) ===\n\n", result.Messages.Total)
 
-		headers := []string{"CHANNEL", "USER", "TIMESTAMP", "TEXT"}
+		headers := []string{"REF", "CHANNEL", "USER", "WHEN", "TEXT"}
 		rows := make([][]string, 0, len(result.Messages.Matches))
 		for _, m := range result.Messages.Matches {
 			body := client.RenderMessage(client.MessageContent{
@@ -131,11 +131,11 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 				Attachments: m.Attachments,
 				Files:       m.Files,
 			}, nil).Body
-			text := truncateText(body, 60)
-			ts := formatTimestamp(m.TS)
-			rows = append(rows, []string{m.Channel.Name, m.Username, ts, text})
+			when := formatTimestamp(m.TS)
+			ref := m.Channel.ID + "/" + m.TS
+			rows = append(rows, []string{ref, m.Channel.Name, m.Username, when, body})
 		}
-		output.Table(headers, rows)
+		output.SearchTable(headers, rows, 60)
 
 		paging := result.Messages.Paging
 		output.Printf("\nPage %d of %d (showing %d of %d messages)\n",
@@ -164,6 +164,10 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 		paging := result.Files.Paging
 		output.Printf("\nPage %d of %d (showing %d of %d files)\n",
 			paging.Page, paging.Pages, len(result.Files.Matches), paging.Total)
+	}
+
+	if hasMessages {
+		output.Println("\nRead: slck --as-user messages read <REF>")
 	}
 
 	return nil

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -126,7 +126,7 @@ func runSearchMessages(query string, opts *messagesOptions, c *client.Client) er
 
 	output.Printf("Found %d messages matching \"%s\"\n\n", result.Messages.Total, query)
 
-	headers := []string{"CHANNEL", "USER", "TIMESTAMP", "TEXT"}
+	headers := []string{"REF", "CHANNEL", "USER", "WHEN", "TEXT"}
 	rows := make([][]string, 0, len(result.Messages.Matches))
 	for _, m := range result.Messages.Matches {
 		body := client.RenderMessage(client.MessageContent{
@@ -135,15 +135,16 @@ func runSearchMessages(query string, opts *messagesOptions, c *client.Client) er
 			Attachments: m.Attachments,
 			Files:       m.Files,
 		}, nil).Body
-		text := truncateText(body, 60)
-		ts := formatTimestamp(m.TS)
-		rows = append(rows, []string{m.Channel.Name, m.Username, ts, text})
+		when := formatTimestamp(m.TS)
+		ref := m.Channel.ID + "/" + m.TS
+		rows = append(rows, []string{ref, m.Channel.Name, m.Username, when, body})
 	}
-	output.Table(headers, rows)
+	output.SearchTable(headers, rows, 60)
 
 	paging := result.Messages.Paging
 	output.Printf("\nPage %d of %d (showing %d of %d results)\n",
 		paging.Page, paging.Pages, len(result.Messages.Matches), paging.Total)
+	output.Println("Read: slck --as-user messages read <REF>")
 
 	return nil
 }

--- a/internal/cmd/search/messages.go
+++ b/internal/cmd/search/messages.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/messageref"
 	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
@@ -136,7 +137,7 @@ func runSearchMessages(query string, opts *messagesOptions, c *client.Client) er
 			Files:       m.Files,
 		}, nil).Body
 		when := formatTimestamp(m.TS)
-		ref := m.Channel.ID + "/" + m.TS
+		ref := messageref.Ref{ChannelID: m.Channel.ID, TS: m.TS}.String()
 		rows = append(rows, []string{ref, m.Channel.Name, m.Username, when, body})
 	}
 	output.SearchTable(headers, rows, 60)

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -943,3 +943,101 @@ func TestSearchMessages_WithSortOptions(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+// TestRunSearchMessages_RefColumnAndFooter verifies the REF column uses
+// channel ID (not channel name) and that the footer hint is emitted when
+// matches are present.
+func TestRunSearchMessages_RefColumnAndFooter(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"type":     "message",
+				"channel":  map[string]interface{}{"id": "C02DF3BEUGN", "name": "engineering"},
+				"user":     "U1",
+				"username": "alice",
+				"text":     "hello",
+				"ts":       "1777469221.721439",
+			}},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		if err := runSearchMessages("hello", &messagesOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchMessages: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "REF | CHANNEL | USER | WHEN | TEXT") {
+		t.Errorf("missing REF header line; got:\n%s", out)
+	}
+	if !strings.Contains(out, "C02DF3BEUGN/1777469221.721439 | engineering |") {
+		t.Errorf("REF should be channel-id/ts; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Read: slck --as-user messages read <REF>") {
+		t.Errorf("missing footer hint; got:\n%s", out)
+	}
+}
+
+func TestRunSearchMessages_NoFooterWhenEmpty(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":   0,
+			"paging":  map[string]interface{}{"count": 20, "total": 0, "page": 1, "pages": 0},
+			"matches": []map[string]interface{}{},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		if err := runSearchMessages("nope", &messagesOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchMessages: %v", err)
+		}
+	})
+
+	if strings.Contains(out, "Read: slck") {
+		t.Errorf("footer should not appear with no results; got:\n%s", out)
+	}
+}
+
+func TestRunSearchAll_FooterOnlyWithMessages(t *testing.T) {
+	// File-only result: footer hint must NOT appear.
+	response := map[string]interface{}{
+		"ok": true,
+		"files": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"id":       "F1",
+				"name":     "report.pdf",
+				"title":    "report",
+				"filetype": "pdf",
+				"user":     "U1",
+				"created":  int64(1704067200),
+			}},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		if err := runSearchAll("query", &allOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchAll: %v", err)
+		}
+	})
+	if strings.Contains(out, "Read: slck") {
+		t.Errorf("footer should be suppressed for file-only results; got:\n%s", out)
+	}
+}

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -1041,3 +1041,33 @@ func TestRunSearchAll_FooterOnlyWithMessages(t *testing.T) {
 		t.Errorf("footer should be suppressed for file-only results; got:\n%s", out)
 	}
 }
+
+func TestRunSearchAll_FooterShownWithMessages(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"type":     "message",
+				"channel":  map[string]interface{}{"id": "C123", "name": "general"},
+				"user":     "U1",
+				"username": "alice",
+				"text":     "hi",
+				"ts":       "1.0",
+			}},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+	out := captureOutput(t, func() {
+		if err := runSearchAll("hi", &allOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchAll: %v", err)
+		}
+	})
+	if !strings.Contains(out, "Read: slck --as-user messages read <REF>") {
+		t.Errorf("footer should appear in messages section; got:\n%s", out)
+	}
+}

--- a/internal/messageref/messageref.go
+++ b/internal/messageref/messageref.go
@@ -1,0 +1,75 @@
+// Package messageref parses and formats Slack message refs.
+//
+// A message ref is the API-level composite identity for a single message in
+// a channel: <channel_id>/<ts>. It exists so CLI commands can hand a single
+// command-ready string between search output and read commands without
+// exposing the fact that lower-level Slack APIs need channel and ts as
+// separate fields.
+package messageref
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
+)
+
+// Ref is a parsed message ref.
+type Ref struct {
+	ChannelID string // e.g. "C02DF3BEUGN"
+	TS        string // canonical API ts, e.g. "1777469221.721439"
+}
+
+// String returns the canonical "<channel_id>/<ts>" form.
+func (r Ref) String() string {
+	return r.ChannelID + "/" + r.TS
+}
+
+// permalinkPattern matches Slack message permalinks.
+// Example: https://workspace.slack.com/archives/C02DF3BEUGN/p1777469221721439
+var permalinkPattern = regexp.MustCompile(`^https?://[^/]+/archives/([A-Z0-9]+)/p(\d{16})(?:\?.*)?$`)
+
+// Parse accepts either a permalink or "<channel_id>/<ts>" and returns a Ref.
+// The ts portion may be in API form (1234567890.123456) or p-prefixed form
+// (p1234567890123456); both are normalized to API form on the resulting Ref.
+func Parse(input string) (Ref, error) {
+	input = strings.TrimSpace(input)
+	if input == "" {
+		return Ref{}, fmt.Errorf("empty message ref")
+	}
+
+	if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
+		m := permalinkPattern.FindStringSubmatch(input)
+		if m == nil {
+			return Ref{}, fmt.Errorf("invalid Slack permalink %q: expected https://<workspace>/archives/<channel>/p<digits>", input)
+		}
+		channel := m[1]
+		digits := m[2]
+		ts := digits[:10] + "." + digits[10:]
+		if err := validate.ChannelID(channel); err != nil {
+			return Ref{}, err
+		}
+		if err := validate.Timestamp(ts); err != nil {
+			return Ref{}, err
+		}
+		return Ref{ChannelID: channel, TS: ts}, nil
+	}
+
+	parts := strings.SplitN(input, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return Ref{}, fmt.Errorf("invalid message ref %q: expected <channel_id>/<ts> or a Slack permalink", input)
+	}
+
+	channel := parts[0]
+	ts := validate.NormalizeTimestamp(parts[1])
+
+	if err := validate.ChannelID(channel); err != nil {
+		return Ref{}, err
+	}
+	if err := validate.Timestamp(ts); err != nil {
+		return Ref{}, err
+	}
+
+	return Ref{ChannelID: channel, TS: ts}, nil
+}

--- a/internal/messageref/messageref.go
+++ b/internal/messageref/messageref.go
@@ -15,6 +15,13 @@ import (
 	"github.com/open-cli-collective/slack-chat-api/internal/validate"
 )
 
+// conversationIDPattern accepts the full set of Slack conversation IDs used as
+// the channel portion of a message ref: public channels (C), private/group
+// channels (G), and DMs (D). validate.ChannelID rejects D, which is correct
+// for channel-only commands but too narrow for refs sourced from search
+// (which can hit DMs with --in @user).
+var conversationIDPattern = regexp.MustCompile(`^[CGD][A-Z0-9]+$`)
+
 // Ref is a parsed message ref.
 type Ref struct {
 	ChannelID string // e.g. "C02DF3BEUGN"
@@ -47,7 +54,7 @@ func Parse(input string) (Ref, error) {
 		channel := m[1]
 		digits := m[2]
 		ts := digits[:10] + "." + digits[10:]
-		if err := validate.ChannelID(channel); err != nil {
+		if err := validateConversationID(channel); err != nil {
 			return Ref{}, err
 		}
 		if err := validate.Timestamp(ts); err != nil {
@@ -64,7 +71,7 @@ func Parse(input string) (Ref, error) {
 	channel := parts[0]
 	ts := validate.NormalizeTimestamp(parts[1])
 
-	if err := validate.ChannelID(channel); err != nil {
+	if err := validateConversationID(channel); err != nil {
 		return Ref{}, err
 	}
 	if err := validate.Timestamp(ts); err != nil {
@@ -72,4 +79,11 @@ func Parse(input string) (Ref, error) {
 	}
 
 	return Ref{ChannelID: channel, TS: ts}, nil
+}
+
+func validateConversationID(id string) error {
+	if !conversationIDPattern.MatchString(id) {
+		return fmt.Errorf("invalid conversation ID %q: must start with C, G, or D", id)
+	}
+	return nil
 }

--- a/internal/messageref/messageref.go
+++ b/internal/messageref/messageref.go
@@ -35,7 +35,7 @@ func (r Ref) String() string {
 
 // permalinkPattern matches Slack message permalinks.
 // Example: https://workspace.slack.com/archives/C02DF3BEUGN/p1777469221721439
-var permalinkPattern = regexp.MustCompile(`^https?://[^/]+/archives/([A-Z0-9]+)/p(\d{16})(?:\?.*)?$`)
+var permalinkPattern = regexp.MustCompile(`^https?://[^/]+/archives/([A-Z0-9]{2,})/p(\d{16})(?:\?.*)?$`)
 
 // Parse accepts either a permalink or "<channel_id>/<ts>" and returns a Ref.
 // The ts portion may be in API form (1234567890.123456) or p-prefixed form

--- a/internal/messageref/messageref_test.go
+++ b/internal/messageref/messageref_test.go
@@ -12,6 +12,8 @@ func TestParse(t *testing.T) {
 	}{
 		{"api form", "C02DF3BEUGN/1777469221.721439", "C02DF3BEUGN", "1777469221.721439", false},
 		{"private channel api form", "G01234ABCDE/1234567890.123456", "G01234ABCDE", "1234567890.123456", false},
+		{"DM api form", "D01234ABCDE/1234567890.123456", "D01234ABCDE", "1234567890.123456", false},
+		{"DM permalink", "https://example.slack.com/archives/D01234ABCDE/p1234567890123456", "D01234ABCDE", "1234567890.123456", false},
 		{"p-prefixed ts", "C02DF3BEUGN/p1777469221721439", "C02DF3BEUGN", "1777469221.721439", false},
 		{"permalink", "https://example.slack.com/archives/C02DF3BEUGN/p1777469221721439", "C02DF3BEUGN", "1777469221.721439", false},
 		{"permalink with thread_ts query", "https://example.slack.com/archives/C02DF3BEUGN/p1777469221721439?thread_ts=1777469200.000000&cid=C02DF3BEUGN", "C02DF3BEUGN", "1777469221.721439", false},

--- a/internal/messageref/messageref_test.go
+++ b/internal/messageref/messageref_test.go
@@ -1,0 +1,74 @@
+package messageref
+
+import "testing"
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name        string
+		input       string
+		wantChannel string
+		wantTS      string
+		wantErr     bool
+	}{
+		{"api form", "C02DF3BEUGN/1777469221.721439", "C02DF3BEUGN", "1777469221.721439", false},
+		{"private channel api form", "G01234ABCDE/1234567890.123456", "G01234ABCDE", "1234567890.123456", false},
+		{"p-prefixed ts", "C02DF3BEUGN/p1777469221721439", "C02DF3BEUGN", "1777469221.721439", false},
+		{"permalink", "https://example.slack.com/archives/C02DF3BEUGN/p1777469221721439", "C02DF3BEUGN", "1777469221.721439", false},
+		{"permalink with thread_ts query", "https://example.slack.com/archives/C02DF3BEUGN/p1777469221721439?thread_ts=1777469200.000000&cid=C02DF3BEUGN", "C02DF3BEUGN", "1777469221.721439", false},
+		{"trims whitespace", "  C02DF3BEUGN/1777469221.721439  ", "C02DF3BEUGN", "1777469221.721439", false},
+
+		{"empty", "", "", "", true},
+		{"missing slash", "C02DF3BEUGN", "", "", true},
+		{"empty channel", "/1234567890.123456", "", "", true},
+		{"empty ts", "C02DF3BEUGN/", "", "", true},
+		{"invalid channel", "X02DF3BEUGN/1234567890.123456", "", "", true},
+		{"user id as channel", "U02DF3BEUGN/1234567890.123456", "", "", true},
+		{"invalid ts", "C02DF3BEUGN/not-a-ts", "", "", true},
+		{"non-permalink http", "https://example.com/foo", "", "", true},
+		{"permalink missing p prefix", "https://example.slack.com/archives/C123/1234567890123456", "", "", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("Parse(%q) err = %v, wantErr %v", tt.input, err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if got.ChannelID != tt.wantChannel || got.TS != tt.wantTS {
+				t.Errorf("Parse(%q) = %+v, want {%s %s}", tt.input, got, tt.wantChannel, tt.wantTS)
+			}
+		})
+	}
+}
+
+func TestRefString(t *testing.T) {
+	r := Ref{ChannelID: "C02DF3BEUGN", TS: "1777469221.721439"}
+	want := "C02DF3BEUGN/1777469221.721439"
+	if got := r.String(); got != want {
+		t.Errorf("String() = %q, want %q", got, want)
+	}
+}
+
+func TestParseRoundTrip(t *testing.T) {
+	inputs := []string{
+		"C02DF3BEUGN/1777469221.721439",
+		"https://example.slack.com/archives/C02DF3BEUGN/p1777469221721439",
+		"C02DF3BEUGN/p1777469221721439",
+	}
+	for _, in := range inputs {
+		r, err := Parse(in)
+		if err != nil {
+			t.Fatalf("Parse(%q) failed: %v", in, err)
+		}
+		r2, err := Parse(r.String())
+		if err != nil {
+			t.Fatalf("Parse(%q.String() = %q) failed: %v", in, r.String(), err)
+		}
+		if r != r2 {
+			t.Errorf("round-trip mismatch: %+v -> %+v", r, r2)
+		}
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -109,6 +109,68 @@ func Table(headers []string, rows [][]string) {
 	}
 }
 
+// SearchTable writes pipe-delimited, unpadded rows for agent-friendly
+// search output: "h1 | h2 | h3" / "v1 | v2 | v3".
+//
+// Cell rules (callers pass raw strings only):
+//   - internal newlines and CRs are collapsed to single spaces
+//   - literal '|' is replaced with U+00A6 '¦' so a downstream parser can
+//     split on " | " deterministically
+//   - only the LAST column is truncated, rune-based, when lastColMaxRunes > 0;
+//     all other columns (REF, IDs, dates, names) render in full
+//
+// If a row's length doesn't match headers, missing cells are padded with ""
+// and extra cells are dropped — no panic.
+func SearchTable(headers []string, rows [][]string, lastColMaxRunes int) {
+	if len(headers) == 0 {
+		return
+	}
+
+	cleanHeaders := make([]string, len(headers))
+	for i, h := range headers {
+		cleanHeaders[i] = sanitizeSearchCell(h)
+	}
+	_, _ = fmt.Fprintln(Writer, strings.Join(cleanHeaders, " | "))
+
+	lastIdx := len(headers) - 1
+	for _, row := range rows {
+		cells := make([]string, len(headers))
+		for i := range headers {
+			var raw string
+			if i < len(row) {
+				raw = row[i]
+			}
+			c := sanitizeSearchCell(raw)
+			if i == lastIdx && lastColMaxRunes > 0 {
+				c = truncateRunes(c, lastColMaxRunes)
+			}
+			cells[i] = c
+		}
+		_, _ = fmt.Fprintln(Writer, strings.Join(cells, " | "))
+	}
+}
+
+func sanitizeSearchCell(s string) string {
+	s = strings.ReplaceAll(s, "\r", "")
+	s = strings.ReplaceAll(s, "\n", " ")
+	s = strings.ReplaceAll(s, "|", "¦")
+	return s
+}
+
+func truncateRunes(s string, max int) string {
+	if max <= 0 {
+		return s
+	}
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 3 {
+		return string(runes[:max])
+	}
+	return string(runes[:max-3]) + "..."
+}
+
 // KeyValue prints a single key-value pair
 func KeyValue(key string, value interface{}) {
 	_, _ = fmt.Fprintf(Writer, "%-12s  %v\n", key+":", value)

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -113,7 +113,7 @@ func Table(headers []string, rows [][]string) {
 // search output: "h1 | h2 | h3" / "v1 | v2 | v3".
 //
 // Cell rules (callers pass raw strings only):
-//   - internal newlines and CRs are collapsed to single spaces
+//   - internal newlines are collapsed to single spaces; carriage returns are stripped
 //   - literal '|' is replaced with U+00A6 '¦' so a downstream parser can
 //     split on " | " deterministically
 //   - only the LAST column is truncated, rune-based, when lastColMaxRunes > 0;

--- a/internal/output/output_test.go
+++ b/internal/output/output_test.go
@@ -1,0 +1,124 @@
+package output
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestSearchTable(t *testing.T) {
+	tests := []struct {
+		name            string
+		headers         []string
+		rows            [][]string
+		lastColMaxRunes int
+		wantContains    []string
+		wantNotContains []string
+	}{
+		{
+			name:    "basic pipe-delimited output",
+			headers: []string{"REF", "USER", "TEXT"},
+			rows: [][]string{
+				{"C123/1.2", "alice", "hello world"},
+			},
+			lastColMaxRunes: 0,
+			wantContains: []string{
+				"REF | USER | TEXT\n",
+				"C123/1.2 | alice | hello world\n",
+			},
+		},
+		{
+			name:    "newlines flattened in cells",
+			headers: []string{"REF", "TEXT"},
+			rows: [][]string{
+				{"C1/1.0", "line one\nline two"},
+			},
+			lastColMaxRunes: 0,
+			wantContains:    []string{"C1/1.0 | line one line two\n"},
+			wantNotContains: []string{"line one\nline two"},
+		},
+		{
+			name:    "literal pipe in cells replaced with broken bar",
+			headers: []string{"REF", "TEXT"},
+			rows: [][]string{
+				{"C1/1.0", "a|b|c"},
+			},
+			lastColMaxRunes: 0,
+			wantContains:    []string{"C1/1.0 | a¦b¦c\n"},
+			wantNotContains: []string{"a|b|c"},
+		},
+		{
+			name:    "only last column truncates",
+			headers: []string{"REF", "USER", "TEXT"},
+			rows: [][]string{
+				{"C1234567890/1234567890.123456", "verylongusername", "this is the body that should get truncated when it grows past the cap"},
+			},
+			lastColMaxRunes: 20,
+			wantContains: []string{
+				"C1234567890/1234567890.123456 | verylongusername | ",
+				"...",
+			},
+			wantNotContains: []string{"truncated when it grows past the cap"},
+		},
+		{
+			name:            "row shorter than headers pads",
+			headers:         []string{"A", "B", "C"},
+			rows:            [][]string{{"x"}},
+			lastColMaxRunes: 0,
+			wantContains:    []string{"A | B | C\n", "x |  | \n"},
+		},
+		{
+			name:            "row longer than headers drops extras",
+			headers:         []string{"A", "B"},
+			rows:            [][]string{{"x", "y", "z"}},
+			lastColMaxRunes: 0,
+			wantContains:    []string{"A | B\n", "x | y\n"},
+			wantNotContains: []string{"z"},
+		},
+		{
+			name:            "empty headers no panic",
+			headers:         nil,
+			rows:            [][]string{{"a"}},
+			lastColMaxRunes: 0,
+			wantContains:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			origWriter := Writer
+			Writer = &buf
+			defer func() { Writer = origWriter }()
+
+			SearchTable(tt.headers, tt.rows, tt.lastColMaxRunes)
+
+			out := buf.String()
+			for _, want := range tt.wantContains {
+				if !strings.Contains(out, want) {
+					t.Errorf("output missing %q\n--- got ---\n%s", want, out)
+				}
+			}
+			for _, dont := range tt.wantNotContains {
+				if strings.Contains(out, dont) {
+					t.Errorf("output should not contain %q\n--- got ---\n%s", dont, out)
+				}
+			}
+		})
+	}
+}
+
+func TestSearchTableTruncatesRunesNotBytes(t *testing.T) {
+	var buf bytes.Buffer
+	origWriter := Writer
+	Writer = &buf
+	defer func() { Writer = origWriter }()
+
+	// 10 multi-byte runes, cap to 5 — should produce 2 runes + "..."
+	SearchTable([]string{"REF", "TEXT"}, [][]string{{"C1/1.0", "你好你好你好你好你好"}}, 5)
+
+	out := buf.String()
+	if !strings.Contains(out, "你好...") {
+		t.Errorf("expected rune-aware truncation, got: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- New `internal/messageref` package: parses `<channel_id>/<ts>` and Slack permalinks into a `Ref` and formats canonically. Reuses `validate` for ts/channel validation; URL grammar lives in `messageref`.
- `slck messages read <ref>`: reads the conversation thread for a ref via `conversations.replies`. Wraps `not_in_channel` with a `--as-user` hint; other errors pass through untouched.
- `search messages` and `search all` (messages section) now use a pipe-delimited table with a leading REF column (channel-id/ts) and a footer hint pointing at `slck --as-user messages read <REF>`. Hint suppressed when no message rows are present (file-only `search all` results don't see it).
- New `output.SearchTable(headers, rows, lastColMaxRunes)` helper — single formatting path for search rows across both #146 and #147 (files). Owns newline flattening, pipe-escape (`|` -> `¦`), and rune-based last-column truncation. Mismatched row widths pad/trim deterministically.
- Thread rendering loop extracted to a shared `renderMessageList` so `messages thread` and `messages read` cannot drift on edited markers, file lines, or user resolution.

JSON output is unchanged: no rendered text fields, no synthetic `ref` field — text output is the only product surface for the new ref + footer hint.

Closes #146

## Test plan
- [x] `go test ./...` — 699 passed
- [x] `make lint` — clean
- [x] `messageref` parse/format covers API form, permalink (with query string), p-prefixed ts, invalid channel/ts/missing slash
- [x] `output.SearchTable` covers pipe-escape, newline flatten, rune truncation, width mismatch
- [x] `search messages` REF column uses channel ID (not name); footer present with results, absent when empty
- [x] `search all` footer suppressed for file-only results
- [x] `messages read` covers success, permalink input, `not_in_channel` hint, unrelated error pass-through, JSON output, invalid ref