### PR TITLE
feat(files): expose file refs in search and add files get

### DIFF
--- a/internal/cmd/files/files.go
+++ b/internal/cmd/files/files.go
@@ -10,6 +10,7 @@ func NewCmd() *cobra.Command {
 	}
 
 	cmd.AddCommand(newDownloadCmd())
+	cmd.AddCommand(newGetCmd())
 
 	return cmd
 }

--- a/internal/cmd/files/get.go
+++ b/internal/cmd/files/get.go
@@ -1,0 +1,66 @@
+package files
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+func newGetCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "get <file-id-or-url>",
+		Short: "Get file metadata",
+		Long: `Get compact plaintext metadata for a Slack file.
+
+Accepts a file ID (e.g. F0AHF3NUSQK) or a Slack file URL
+(url_private, url_private_download, or permalink).
+
+Pairs with 'slck files download <ref>' for the search-to-get/download
+workflow: refs from 'slck search files' can be passed directly.`,
+		Args: cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGet(args[0], nil)
+		},
+	}
+	return cmd
+}
+
+func runGet(input string, c *client.Client) error {
+	fileID := resolveFileID(input)
+	if fileID == "" {
+		return fmt.Errorf("could not resolve file ID from %q — provide a file ID (e.g. F0AHF3NUSQK) or Slack file URL", input)
+	}
+
+	if c == nil {
+		var err error
+		c, err = client.New()
+		if err != nil {
+			return err
+		}
+	}
+
+	info, err := c.GetFileInfo(fileID)
+	if err != nil {
+		return err
+	}
+
+	if output.IsJSON() {
+		return output.PrintJSON(info)
+	}
+
+	output.Printf("ID: %s\n", info.ID)
+	output.Printf("Name: %s\n", info.Name)
+	if info.Title != "" {
+		output.Printf("Title: %s\n", info.Title)
+	}
+	if info.Filetype != "" {
+		output.Printf("Type: %s\n", info.Filetype)
+	}
+	output.Printf("Size: %s\n", output.HumanSize(info.Size))
+	output.Printf("Download: slck files download %s\n", info.ID)
+
+	return nil
+}

--- a/internal/cmd/files/get_test.go
+++ b/internal/cmd/files/get_test.go
@@ -119,3 +119,27 @@ func TestRunGet_JSONOutputRaw(t *testing.T) {
 	assert.NotContains(t, parsed, "download")
 	assert.NotContains(t, parsed, "hint")
 }
+
+func TestRunGet_NegativeSizeRendersZero(t *testing.T) {
+	c, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":   true,
+			"file": map[string]interface{}{"id": "F1", "name": "snippet", "size": -1},
+		})
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() { require.NoError(t, runGet("F1", c)) })
+	assert.Contains(t, out, "Size: 0 B\n")
+}
+
+func TestRunGet_APIErrorPropagates(t *testing.T) {
+	c, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{"ok": false, "error": "file_not_found"})
+	})
+	defer server.Close()
+
+	err := runGet("F0ABC123", c)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "file_not_found")
+}

--- a/internal/cmd/files/get_test.go
+++ b/internal/cmd/files/get_test.go
@@ -1,0 +1,121 @@
+package files
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+)
+
+func newTestClient(t *testing.T, handler http.HandlerFunc) (*client.Client, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewServer(handler)
+	return client.NewWithConfig(server.URL, "test-token", nil), server
+}
+
+func captureOutput(t *testing.T, fn func()) string {
+	t.Helper()
+	var buf strings.Builder
+	orig := output.Writer
+	output.Writer = &buf
+	defer func() { output.Writer = orig }()
+	fn()
+	return buf.String()
+}
+
+func TestRunGet_Success(t *testing.T) {
+	c, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/files.info", r.URL.Path)
+		assert.Equal(t, "F0ABC123", r.URL.Query().Get("file"))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"file": map[string]interface{}{
+				"id":       "F0ABC123",
+				"name":     "report.pdf",
+				"title":    "Quarterly report",
+				"filetype": "pdf",
+				"size":     60620,
+			},
+		})
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		require.NoError(t, runGet("F0ABC123", c))
+	})
+
+	assert.Contains(t, out, "ID: F0ABC123\n")
+	assert.Contains(t, out, "Name: report.pdf\n")
+	assert.Contains(t, out, "Title: Quarterly report\n")
+	assert.Contains(t, out, "Type: pdf\n")
+	assert.Contains(t, out, "Size: 59.2 KB\n")
+	assert.Contains(t, out, "Download: slck files download F0ABC123\n")
+	// No multi-space alignment leaks in.
+	assert.NotContains(t, out, "ID:        ")
+}
+
+func TestRunGet_AcceptsURL(t *testing.T) {
+	c, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "F0ABC123", r.URL.Query().Get("file"))
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":   true,
+			"file": map[string]interface{}{"id": "F0ABC123", "name": "x", "size": 0},
+		})
+	})
+	defer server.Close()
+
+	require.NoError(t, runGet("https://files.slack.com/files-pri/T1-F0ABC123/x.pdf", c))
+}
+
+func TestRunGet_OmitsEmptyTitleAndType(t *testing.T) {
+	c, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":   true,
+			"file": map[string]interface{}{"id": "F1", "name": "x.bin", "size": 100},
+		})
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() { require.NoError(t, runGet("F1", c)) })
+	assert.NotContains(t, out, "Title:")
+	assert.NotContains(t, out, "Type:")
+}
+
+func TestRunGet_InvalidRef(t *testing.T) {
+	err := runGet("not-a-ref", nil)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "could not resolve file ID")
+}
+
+func TestRunGet_JSONOutputRaw(t *testing.T) {
+	c, server := newTestClient(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok": true,
+			"file": map[string]interface{}{
+				"id": "F0ABC123", "name": "report.pdf", "title": "Q1", "filetype": "pdf", "size": 100,
+			},
+		})
+	})
+	defer server.Close()
+
+	origFmt := output.OutputFormat
+	output.OutputFormat = output.FormatJSON
+	defer func() { output.OutputFormat = origFmt }()
+
+	out := captureOutput(t, func() { require.NoError(t, runGet("F0ABC123", c)) })
+
+	var parsed map[string]interface{}
+	require.NoError(t, json.Unmarshal([]byte(out), &parsed))
+	// Raw upstream-shaped File. No synthetic ref/hint/download keys.
+	assert.Equal(t, "F0ABC123", parsed["id"])
+	assert.NotContains(t, parsed, "ref")
+	assert.NotContains(t, parsed, "download")
+	assert.NotContains(t, parsed, "hint")
+}

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
 )
 
 // NewCmd creates the messages command with all subcommands
@@ -115,36 +116,12 @@ func renderFiles(files []client.File) string {
 			b.WriteString(f.Filetype)
 			b.WriteString(", ")
 		}
-		b.WriteString(humanSize(f.Size))
+		b.WriteString(output.HumanSize(f.Size))
 		b.WriteString(") — slck files download ")
 		b.WriteString(f.ID)
 		b.WriteString("\n")
 	}
 	return b.String()
-}
-
-// humanSize formats a byte count as "411 B", "12.3 KB", "4.5 MB", etc.
-// Slack occasionally returns size=-1 for certain snippet types; clamp
-// negatives to 0 rather than render "-1 B".
-func humanSize(n int64) string {
-	if n < 0 {
-		n = 0
-	}
-	const (
-		kb = 1024
-		mb = 1024 * kb
-		gb = 1024 * mb
-	)
-	switch {
-	case n < kb:
-		return fmt.Sprintf("%d B", n)
-	case n < mb:
-		return fmt.Sprintf("%.1f KB", float64(n)/kb)
-	case n < gb:
-		return fmt.Sprintf("%.1f MB", float64(n)/mb)
-	default:
-		return fmt.Sprintf("%.1f GB", float64(n)/gb)
-	}
 }
 
 // unescapeShellChars removes backslash escaping from common shell-escaped characters.

--- a/internal/cmd/messages/messages_test.go
+++ b/internal/cmd/messages/messages_test.go
@@ -1743,7 +1743,7 @@ func TestHumanSize(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.expected, humanSize(tt.n))
+			assert.Equal(t, tt.expected, output.HumanSize(tt.n))
 		})
 	}
 }

--- a/internal/cmd/search/all.go
+++ b/internal/cmd/search/all.go
@@ -153,19 +153,18 @@ func runSearchAll(query string, opts *allOptions, c *client.Client) error {
 	if hasFiles {
 		output.Printf("=== Files (%d total) ===\n\n", result.Files.Total)
 
-		headers := []string{"NAME", "TYPE", "USER", "CREATED", "TITLE"}
+		headers := []string{"REF", "TYPE", "USER", "CREATED", "NAME"}
 		rows := make([][]string, 0, len(result.Files.Matches))
 		for _, f := range result.Files.Matches {
-			name := truncateText(f.Name, 30)
-			title := truncateText(f.Title, 40)
 			created := formatUnixTimestamp(f.Created)
-			rows = append(rows, []string{name, f.Filetype, f.User, created, title})
+			rows = append(rows, []string{f.ID, f.Filetype, f.User, created, fileLabel(f.Name, f.Title)})
 		}
-		output.Table(headers, rows)
+		output.SearchTable(headers, rows, 60)
 
 		paging := result.Files.Paging
 		output.Printf("\nPage %d of %d (showing %d of %d files)\n",
 			paging.Page, paging.Pages, len(result.Files.Matches), paging.Total)
+		output.Println("Get: slck files get <REF>")
 	}
 
 	return nil

--- a/internal/cmd/search/files.go
+++ b/internal/cmd/search/files.go
@@ -130,7 +130,9 @@ func runSearchFiles(query string, opts *filesOptions, c *client.Client) error {
 	paging := result.Files.Paging
 	output.Printf("\nPage %d of %d (showing %d of %d results)\n",
 		paging.Page, paging.Pages, len(result.Files.Matches), paging.Total)
-	output.Println("Get: slck files get <REF>")
+	if len(rows) > 0 {
+		output.Println("Get: slck files get <REF>")
+	}
 
 	return nil
 }

--- a/internal/cmd/search/files.go
+++ b/internal/cmd/search/files.go
@@ -119,21 +119,37 @@ func runSearchFiles(query string, opts *filesOptions, c *client.Client) error {
 
 	output.Printf("Found %d files matching \"%s\"\n\n", result.Files.Total, query)
 
-	headers := []string{"NAME", "TYPE", "USER", "CREATED", "TITLE"}
+	headers := []string{"REF", "TYPE", "USER", "CREATED", "NAME"}
 	rows := make([][]string, 0, len(result.Files.Matches))
 	for _, f := range result.Files.Matches {
-		name := truncateText(f.Name, 30)
-		title := truncateText(f.Title, 40)
 		created := formatUnixTimestamp(f.Created)
-		rows = append(rows, []string{name, f.Filetype, f.User, created, title})
+		rows = append(rows, []string{f.ID, f.Filetype, f.User, created, fileLabel(f.Name, f.Title)})
 	}
-	output.Table(headers, rows)
+	output.SearchTable(headers, rows, 60)
 
 	paging := result.Files.Paging
 	output.Printf("\nPage %d of %d (showing %d of %d results)\n",
 		paging.Page, paging.Pages, len(result.Files.Matches), paging.Total)
+	output.Println("Get: slck files get <REF>")
 
 	return nil
+}
+
+// fileLabel joins file name and title with " · " when both are present and
+// distinct. Slack can return either as empty (anonymous snippets,
+// title-only attachments) so empty parts drop rather than render as a
+// leading or trailing separator.
+func fileLabel(name, title string) string {
+	switch {
+	case name == "" && title == "":
+		return ""
+	case name == "":
+		return title
+	case title == "" || title == name:
+		return name
+	default:
+		return name + " · " + title
+	}
 }
 
 func formatUnixTimestamp(ts int64) string {

--- a/internal/cmd/search/search_test.go
+++ b/internal/cmd/search/search_test.go
@@ -1071,3 +1071,131 @@ func TestRunSearchAll_FooterShownWithMessages(t *testing.T) {
 		t.Errorf("footer should appear in messages section; got:\n%s", out)
 	}
 }
+
+func TestRunSearchFiles_RefColumnAndFooter(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"files": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"id":       "F0ABC123",
+				"name":     "report.pdf",
+				"title":    "Quarterly report",
+				"filetype": "pdf",
+				"user":     "U1",
+				"created":  int64(1704067200),
+			}},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		if err := runSearchFiles("report", &filesOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchFiles: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "REF | TYPE | USER | CREATED | NAME") {
+		t.Errorf("missing REF header line; got:\n%s", out)
+	}
+	if !strings.Contains(out, "F0ABC123 | pdf | U1 | ") {
+		t.Errorf("REF column not at start of row; got:\n%s", out)
+	}
+	if !strings.Contains(out, " | report.pdf · Quarterly report") {
+		t.Errorf("fileLabel not joined with separator; got:\n%s", out)
+	}
+	if !strings.Contains(out, "Get: slck files get <REF>") {
+		t.Errorf("missing footer hint; got:\n%s", out)
+	}
+}
+
+func TestRunSearchFiles_NoFooterWhenEmpty(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"files": map[string]interface{}{
+			"total":   0,
+			"paging":  map[string]interface{}{"count": 20, "total": 0, "page": 1, "pages": 0},
+			"matches": []map[string]interface{}{},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		if err := runSearchFiles("nope", &filesOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchFiles: %v", err)
+		}
+	})
+	if strings.Contains(out, "Get: slck") {
+		t.Errorf("footer should not appear with no results; got:\n%s", out)
+	}
+}
+
+func TestRunSearchAll_BothFootersInTheirSections(t *testing.T) {
+	response := map[string]interface{}{
+		"ok": true,
+		"messages": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"type": "message", "channel": map[string]interface{}{"id": "C1", "name": "g"},
+				"user": "U1", "username": "alice", "text": "hi", "ts": "1.0",
+			}},
+		},
+		"files": map[string]interface{}{
+			"total":  1,
+			"paging": map[string]interface{}{"count": 20, "total": 1, "page": 1, "pages": 1},
+			"matches": []map[string]interface{}{{
+				"id": "F1", "name": "x.pdf", "title": "X", "filetype": "pdf", "user": "U1", "created": int64(1704067200),
+			}},
+		},
+	}
+	c, server := newTestClient(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(response)
+	})
+	defer server.Close()
+
+	out := captureOutput(t, func() {
+		if err := runSearchAll("q", &allOptions{count: 20, page: 1, sort: "score", sortDir: "desc"}, c); err != nil {
+			t.Fatalf("runSearchAll: %v", err)
+		}
+	})
+	idxRead := strings.Index(out, "Read: slck --as-user messages read <REF>")
+	idxFiles := strings.Index(out, "=== Files")
+	idxGet := strings.Index(out, "Get: slck files get <REF>")
+	if idxRead < 0 || idxFiles < 0 || idxGet < 0 {
+		t.Fatalf("missing one of expected sections; got:\n%s", out)
+	}
+	// messages hint must appear before the files section header
+	if idxRead > idxFiles {
+		t.Errorf("messages hint should appear before files section; got:\n%s", out)
+	}
+	// files hint must appear after the files section header
+	if idxGet < idxFiles {
+		t.Errorf("files hint should appear after files section header; got:\n%s", out)
+	}
+}
+
+func TestFileLabel(t *testing.T) {
+	tests := []struct {
+		name, title, want string
+	}{
+		{"report.pdf", "Quarterly report", "report.pdf · Quarterly report"},
+		{"report.pdf", "report.pdf", "report.pdf"},
+		{"report.pdf", "", "report.pdf"},
+		{"", "Quarterly report", "Quarterly report"},
+		{"", "", ""},
+	}
+	for _, tt := range tests {
+		got := fileLabel(tt.name, tt.title)
+		if got != tt.want {
+			t.Errorf("fileLabel(%q, %q) = %q, want %q", tt.name, tt.title, got, tt.want)
+		}
+	}
+}

--- a/internal/output/output.go
+++ b/internal/output/output.go
@@ -171,6 +171,30 @@ func truncateRunes(s string, max int) string {
 	return string(runes[:max-3]) + "..."
 }
 
+// HumanSize formats a byte count as "411 B", "12.3 KB", "4.5 MB", etc.
+// Slack occasionally returns size=-1 for certain snippet types; clamp
+// negatives to 0 rather than render "-1 B".
+func HumanSize(n int64) string {
+	if n < 0 {
+		n = 0
+	}
+	const (
+		kb = 1024
+		mb = 1024 * kb
+		gb = 1024 * mb
+	)
+	switch {
+	case n < kb:
+		return fmt.Sprintf("%d B", n)
+	case n < mb:
+		return fmt.Sprintf("%.1f KB", float64(n)/kb)
+	case n < gb:
+		return fmt.Sprintf("%.1f MB", float64(n)/mb)
+	default:
+		return fmt.Sprintf("%.1f GB", float64(n)/gb)
+	}
+}
+
 // KeyValue prints a single key-value pair
 func KeyValue(key string, value interface{}) {
 	_, _ = fmt.Fprintf(Writer, "%-12s  %v\n", key+":", value)


### PR DESCRIPTION
## Summary
- New `slck files get <file-id-or-url>` returns compact metadata + a download hint. Single-space `Key: Value` text, no column padding. Reuses `resolveFileID` from `files download` for input handling.
- `search files` and `search all` (file section) emit a leading REF column (Slack file ID) via the shared `output.SearchTable` helper from #146, with a `Get: slck files get <REF>` footer hint inside each section. Hint suppressed when no file rows.
- NAME and TITLE collapsed into a single trailing NAME column rendered as `name · title` when they differ, otherwise just `name` (avoids two free-text columns since `SearchTable` only truncates the last).
- `humanSize` relocated from `internal/cmd/messages` to `internal/output` as `HumanSize` so both packages can call it without cross-coupling.

JSON output is unchanged — no synthetic ref/hint/download keys; `files get` returns the raw upstream `*File`.

Closes #147

## Test plan
- [x] `go test ./...` — 712 passed
- [x] `make lint` — clean
- [x] `files get` covers success, URL input, omitted Title/Type, invalid ref, JSON returns raw `File`
- [x] `search files` REF column + footer present with results, absent when empty
- [x] `search all` both hints appear in their respective sections in correct order
- [x] `fileLabel` covers all empty/distinct/equal combinations