### PR TITLE
chore: bump Go toolchain to 1.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
 
       - name: Download dependencies
         run: go mod download
@@ -32,7 +32,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.21'
+          go-version: '1.24'
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          go-version: "1.24"
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.github/workflows/test-chocolatey.yml
+++ b/.github/workflows/test-chocolatey.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          go-version: '1.24'
 
       - name: Build binary for testing
         run: go build -o packaging/chocolatey/tools/slck.exe ./cmd/slck

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ Thank you for your interest in contributing to slack-chat-api!
 
 ### Prerequisites
 
-- Go 1.21 or later
+- Go 1.24 or later
 - Make
 - golangci-lint v2.0+ (for linting)
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-cli-collective/slack-chat-api
 
-go 1.24.0
+go 1.24
 
 require (
 	github.com/spf13/cobra v1.8.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/open-cli-collective/slack-chat-api
 
-go 1.21
+go 1.24.0
 
 require (
 	github.com/spf13/cobra v1.8.0


### PR DESCRIPTION
## What

Bumps the module + CI to **Go 1.24**. Infra-only — **zero source/behavior change** (diff is 6 lines across 5 files).

| File | From → To |
|---|---|
| `go.mod` | `go 1.21` → `go 1.24.0` |
| `.github/workflows/ci.yml` (build-and-test + lint) | `1.21` → `1.24` |
| `.github/workflows/release.yml` | `1.22` → `1.24` |
| `.github/workflows/test-chocolatey.yml` | `1.22` → `1.24` |
| `CONTRIBUTING.md` | `Go 1.21 or later` → `1.24` |

## Why

**Phase B prerequisite (B0):** `slack-chat-api` must be on Go 1.24 to import `github.com/open-cli-collective/cli-common` (`go 1.24`) in the upcoming credstore migration (B1). Also resolves the **pre-existing version skew** (CI tested 1.21 while release built 1.22).

## Verification

- `go build` / `go vet` / `gofmt -l` / `go test ./...` — all clean on Go 1.24
- **Pinned `golangci-lint v2.0.2`** (the exact CI pin, not a newer local binary) run against the bumped 1.24 module → **0 issues**. CI lint action version intentionally left unchanged (minimal diff).
- `go.mod` introduces no `toolchain` directive (single `go` line change).

## Note (pre-existing, unrelated)

`TestRunInit_WrongTokenType` is non-hermetic on **macOS only** (it neither skips on `IsSecureStorage()` nor isolates `XDG_CONFIG_HOME`, so it reads the real login keychain and can race other packages' `security` shell-outs during parallel `go test ./...`). It is **not caused by this bump** (reproduces independent of the `go` directive; flaky by timing) and **does not affect CI** (Linux → file fallback, single process). It will be made hermetic in B1 when slck's keychain layer moves to credstore.

Closes #155
[INT-436]