### PR TITLE
feat(messages): add permalink command and send --permalink flag

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -279,6 +279,7 @@ type Message struct {
 	Files       []File       `json:"files,omitempty"`
 	Blocks      []Block      `json:"blocks,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
+	Permalink   string       `json:"permalink,omitempty"`
 }
 
 // Team represents workspace info
@@ -709,6 +710,30 @@ func (c *Client) ListEmoji() (map[string]string, error) {
 	}
 
 	return result.Emoji, nil
+}
+
+// GetPermalink returns a canonical permalink URL to a specific message
+// via chat.getPermalink. Slack resolves the correct link for top-level
+// messages, thread replies, and enterprise-grid workspaces — preferred
+// over hand-constructing an archive URL.
+func (c *Client) GetPermalink(channel, messageTS string) (string, error) {
+	params := url.Values{}
+	params.Set("channel", channel)
+	params.Set("message_ts", messageTS)
+
+	body, err := c.get("chat.getPermalink", params)
+	if err != nil {
+		return "", err
+	}
+
+	var result struct {
+		Permalink string `json:"permalink"`
+	}
+	if err := json.Unmarshal(body, &result); err != nil {
+		return "", err
+	}
+
+	return result.Permalink, nil
 }
 
 // GetTeamInfo returns workspace info

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1454,3 +1454,54 @@ func TestClient_DeleteCanvas_Success(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 }
+
+func TestClient_GetPermalink_Success(t *testing.T) {
+	const want = "https://signalft.slack.com/archives/C123456/p1234567890123456"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "GET" {
+			t.Errorf("expected GET, got %s", r.Method)
+		}
+		if !strings.Contains(r.URL.Path, "chat.getPermalink") {
+			t.Errorf("expected path to contain chat.getPermalink, got %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("channel"); got != "C123456" {
+			t.Errorf("expected channel=C123456, got %s", got)
+		}
+		if got := r.URL.Query().Get("message_ts"); got != "1234567890.123456" {
+			t.Errorf("expected message_ts=1234567890.123456, got %s", got)
+		}
+		if auth := r.Header.Get("Authorization"); !strings.HasPrefix(auth, "Bearer ") {
+			t.Error("expected Authorization header with Bearer prefix")
+		}
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":        true,
+			"channel":   "C123456",
+			"permalink": want,
+		})
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	got, err := client.GetPermalink("C123456", "1234567890.123456")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != want {
+		t.Errorf("expected permalink %q, got %q", want, got)
+	}
+}
+
+func TestClient_GetPermalink_Error(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":    false,
+			"error": "message_not_found",
+		})
+	}))
+	defer server.Close()
+
+	client := NewWithConfig(server.URL, "test-token", nil)
+	if _, err := client.GetPermalink("C123456", "1234567890.123456"); err == nil {
+		t.Fatal("expected an error for a not-OK response, got nil")
+	}
+}

--- a/internal/cmd/messages/messages.go
+++ b/internal/cmd/messages/messages.go
@@ -29,6 +29,7 @@ func NewCmd() *cobra.Command {
 	cmd.AddCommand(newReadCmd())
 	cmd.AddCommand(newReactCmd())
 	cmd.AddCommand(newUnreactCmd())
+	cmd.AddCommand(newPermalinkCmd())
 
 	return cmd
 }

--- a/internal/cmd/messages/permalink.go
+++ b/internal/cmd/messages/permalink.go
@@ -1,0 +1,69 @@
+package messages
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/open-cli-collective/slack-chat-api/internal/client"
+	"github.com/open-cli-collective/slack-chat-api/internal/output"
+	"github.com/open-cli-collective/slack-chat-api/internal/validate"
+)
+
+type permalinkOptions struct{}
+
+func newPermalinkCmd() *cobra.Command {
+	opts := &permalinkOptions{}
+
+	return &cobra.Command{
+		Use:   "permalink <channel> <timestamp>",
+		Short: "Get a permalink URL to a message",
+		Long: `Get a canonical permalink URL to a specific message.
+
+Wraps Slack's chat.getPermalink, which returns the correct link for
+top-level messages, thread replies, and enterprise-grid workspaces —
+preferred over constructing an archive URL by hand.
+
+  slck messages permalink C1234567890 1234567890.123456
+  slck messages permalink C1234567890 1234567890.123456 -o json`,
+		Args: cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runPermalink(args[0], args[1], opts, nil)
+		},
+	}
+}
+
+func runPermalink(channel, timestamp string, _ *permalinkOptions, c *client.Client) error {
+	if err := validate.Timestamp(timestamp); err != nil {
+		return err
+	}
+	timestamp = validate.NormalizeTimestamp(timestamp)
+
+	if c == nil {
+		var err error
+		c, err = client.New()
+		if err != nil {
+			return err
+		}
+	}
+
+	channelID, err := c.ResolveChannel(channel)
+	if err != nil {
+		return err
+	}
+
+	permalink, err := c.GetPermalink(channelID, timestamp)
+	if err != nil {
+		return client.WrapError("get permalink", err)
+	}
+
+	if output.IsJSON() {
+		return output.PrintJSON(map[string]interface{}{
+			"ok":        true,
+			"channel":   channelID,
+			"ts":        timestamp,
+			"permalink": permalink,
+		})
+	}
+
+	output.Printf("%s\n", permalink)
+	return nil
+}

--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -26,6 +26,7 @@ type sendOptions struct {
 	noUnfurl    bool
 	files       []string
 	fileTitle   string
+	permalink   bool
 	stdin       io.Reader // For testing
 }
 
@@ -109,6 +110,7 @@ The channel can also be specified via --channel instead of as a positional argum
 	cmd.Flags().BoolVar(&opts.noUnfurl, "no-unfurl", false, "Disable link preview unfurling")
 	cmd.Flags().StringArrayVar(&opts.files, "file", nil, "File(s) to upload (can be specified multiple times)")
 	cmd.Flags().StringVar(&opts.fileTitle, "file-title", "", "Custom title for uploaded file(s)")
+	cmd.Flags().BoolVar(&opts.permalink, "permalink", false, "After sending, fetch and include the message permalink (one extra API call)")
 
 	return cmd
 }
@@ -240,11 +242,25 @@ func runSend(channel, text string, opts *sendOptions, c *client.Client) error {
 		return client.WrapError("send message", err)
 	}
 
+	// chat.postMessage doesn't return a permalink, so fetch it on request.
+	// Best-effort: the message is already sent, so a failed permalink lookup
+	// warns rather than failing the command.
+	if opts.permalink {
+		if link, perr := c.GetPermalink(channelID, msg.TS); perr == nil {
+			msg.Permalink = link
+		} else {
+			fmt.Fprintf(os.Stderr, "warning: message sent (ts %s) but permalink fetch failed: %v\n", msg.TS, perr)
+		}
+	}
+
 	if output.IsJSON() {
 		return output.PrintJSON(msg)
 	}
 
 	output.Printf("Message sent (ts: %s)\n", msg.TS)
+	if msg.Permalink != "" {
+		output.Printf("%s\n", msg.Permalink)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary

slck had no way to get a message's permalink: `messages send -o json` returns only `{channel, ts, ok}`, and there was no permalink command. Callers were left hand-constructing archive URLs (`https://<domain>.slack.com/archives/<channel>/p<ts>`), which is brittle — wrong for thread replies and enterprise-grid workspaces, and it requires a separate `workspace info` lookup plus dot-stripping.

This adds first-class permalink support via Slack's `chat.getPermalink` (the canonical link).

## What

- **`messages permalink <channel> <timestamp>`** — wraps `chat.getPermalink`. Text output is the bare URL; `-o json` returns `{ok, channel, ts, permalink}`.
- **`messages send --permalink`** — opt-in flag that fetches the permalink right after a successful send and includes it in the output (`Message.Permalink`, `omitempty`). Opt-in so it never adds an API call to a plain send; **best-effort**, so a failed permalink lookup warns on stderr rather than failing an already-sent message.
- **`client.GetPermalink(channel, ts)`** + unit tests (success + not-OK error path).

## Notes

- `go build ./...` + `go test ./...` green; `messages permalink --help` and the `send --permalink` flag verified via the built CLI.
- The `send` JSON shape is additive (`permalink` only appears when the flag is set), so existing parsers are unaffected.
