### PR TITLE
fix(messages): include channel and ok in send -o json output

### DIFF
--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -280,6 +280,11 @@ type Message struct {
 	Blocks      []Block      `json:"blocks,omitempty"`
 	Attachments []Attachment `json:"attachments,omitempty"`
 	Permalink   string       `json:"permalink,omitempty"`
+	// Response-level fields, set on a freshly-sent message so `messages
+	// send -o json` is the documented {ok, channel, ts, …} shape and
+	// downstream tooling can read the channel back (e.g. to delete it).
+	Channel string `json:"channel,omitempty"`
+	OK      bool   `json:"ok,omitempty"`
 }
 
 // Team represents workspace info

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -1505,3 +1505,24 @@ func TestClient_GetPermalink_Error(t *testing.T) {
 		t.Fatal("expected an error for a not-OK response, got nil")
 	}
 }
+
+func TestMessage_SendResponseFields(t *testing.T) {
+	// A freshly-sent message carries the response-level channel + ok so
+	// `messages send -o json` is the documented {ok, channel, ts, …} shape.
+	sent, err := json.Marshal(Message{TS: "123.456", Channel: "C1", OK: true})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if !strings.Contains(string(sent), `"channel":"C1"`) || !strings.Contains(string(sent), `"ok":true`) {
+		t.Errorf("send message JSON missing channel/ok: %s", sent)
+	}
+
+	// History/thread items carry neither — omitempty keeps them out.
+	item, err := json.Marshal(Message{TS: "123.456", Text: "hi"})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if strings.Contains(string(item), `"channel"`) || strings.Contains(string(item), `"ok"`) {
+		t.Errorf("history-item JSON should omit channel/ok: %s", item)
+	}
+}

--- a/internal/cmd/messages/send.go
+++ b/internal/cmd/messages/send.go
@@ -241,6 +241,11 @@ func runSend(channel, text string, opts *sendOptions, c *client.Client) error {
 	if err != nil {
 		return client.WrapError("send message", err)
 	}
+	// SendMessage returns Slack's `message` object, which omits the
+	// response-level channel + ok. Set them so `-o json` is the documented
+	// {ok, channel, ts, …} shape and callers can read the channel back.
+	msg.Channel = channelID
+	msg.OK = true
 
 	// chat.postMessage doesn't return a permalink, so fetch it on request.
 	// Best-effort: the message is already sent, so a failed permalink lookup


### PR DESCRIPTION
## Summary

`messages send -o json` printed Slack's raw `message` object, which **omits the response-level `channel` and `ok`**. So the output was `{type, user, text, ts, …}` — not the documented `{ok, channel, ts, …}` shape — and callers couldn't read the channel back from a send (e.g. to delete the message they just posted, or to build a permalink). This silently broke the unwind path in tests that `send` then `delete`.

## Fix

After a successful send, set `Channel` (the resolved channel) and `OK` on the returned `Message`. Both are `omitempty` on the shared `Message` struct, so history/thread items are unchanged.

`send -o json` is now, e.g.:

```json
{ "ok": true, "channel": "C02DF3BEUGN", "ts": "1779792755.132439" }
```

(plus `permalink` when `--permalink` is passed, from #167).

## Verification

- Serialization test added (channel/ok present for sends, absent on history items via `omitempty`).
- `go build ./...` + `go test ./...` green.
- **Live:** `messages send -o json` returned `{ok, channel, ts}`, and the channel round-tripped to a clean `messages delete`.
