### PR TITLE
chore(deps): bump cli-common to v0.2.1 (pass backend recognized)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/open-cli-collective/slack-chat-api
 go 1.26
 
 require (
-	github.com/open-cli-collective/cli-common v0.2.0
+	github.com/open-cli-collective/cli-common v0.2.1
 	github.com/spf13/cobra v1.8.0
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/term v0.43.0

--- a/go.sum
+++ b/go.sum
@@ -43,8 +43,8 @@ github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWb
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
 github.com/noamcohen97/touchid-go v0.3.0 h1:fcXxVCizysD7KHRR6hrURt3nyNIs5JBGSbOIidD/3wo=
 github.com/noamcohen97/touchid-go v0.3.0/go.mod h1:X9MRNIBGEmPqwpDm1G3fQOAQX7fwBlhzUbnkDTxuta0=
-github.com/open-cli-collective/cli-common v0.2.0 h1:EOqf75BIA2tfFrGNmYB1jCjFH0jogIgsYqj6JPXoOQA=
-github.com/open-cli-collective/cli-common v0.2.0/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
+github.com/open-cli-collective/cli-common v0.2.1 h1:awnwmDD9ubGUmYLg+SGkPGzbiraJsJb/eMWWTV4fwPI=
+github.com/open-cli-collective/cli-common v0.2.1/go.mod h1:SVYUmomKzKPrEluJiV1KZc1qnujW5zOKc0mJf0fcm6M=
 github.com/opentracing/opentracing-go v1.2.0 h1:uEJPy/1a5RIPAJ0Ov+OIO8OxWu77jEv+1B0VhjKrZUs=
 github.com/opentracing/opentracing-go v1.2.0/go.mod h1:GxEUsuufX4nBwe+T+Wl9TAgYrxe9dPLANfrWvHYVTgc=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=


### PR DESCRIPTION
Picks up open-cli-collective/cli-common#26: the `pass(1)` backend is now in credstore's recognized backend set. No code changes — the existing `--backend` wiring passes `pass` through to credstore as an opaque string.

After merge: `slck --backend pass <cmd>` works for users with the `pass(1)` CLI on `$PATH` and an initialized password-store.