### PR TITLE
fix(me): exit non-zero when no token authenticates

### DIFF
--- a/internal/cmd/me/me.go
+++ b/internal/cmd/me/me.go
@@ -1,6 +1,8 @@
 package me
 
 import (
+	"errors"
+
 	"github.com/spf13/cobra"
 
 	"github.com/open-cli-collective/slack-chat-api/internal/client"
@@ -99,9 +101,7 @@ func runMe(opts *meOptions, botClient *client.Client, userClient *client.Client)
 
 	// Check if any token worked
 	if result.Bot == nil && result.User == nil {
-		output.Println("No valid tokens configured.")
-		output.Println("Run 'slck init' to configure authentication.")
-		return nil
+		return errors.New("no bot or user token authenticated; run 'slck init' to configure authentication")
 	}
 
 	if output.IsJSON() {

--- a/internal/cmd/me/me_test.go
+++ b/internal/cmd/me/me_test.go
@@ -100,10 +100,14 @@ func TestRunMe_NoTokens(t *testing.T) {
 
 	// Pass nil clients to trigger token lookup
 	err := runMe(opts, nil, nil)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no bot or user token authenticated")
 }
 
 func TestRunMe_AuthFailed(t *testing.T) {
+	// Hermetic empty keyring so the nil userClient doesn't pick up real credentials.
+	testutil.Setup(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		_ = json.NewEncoder(w).Encode(map[string]interface{}{
@@ -116,9 +120,22 @@ func TestRunMe_AuthFailed(t *testing.T) {
 	botClient := client.NewWithConfig(server.URL, "bad-token", nil)
 	opts := &meOptions{}
 
-	// Auth fails, but function should handle gracefully
 	err := runMe(opts, botClient, nil)
-	require.NoError(t, err)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no bot or user token authenticated")
+}
+
+func TestNewCmd_NoTokens_ReturnsError(t *testing.T) {
+	testutil.Setup(t)
+
+	cmd := NewCmd()
+	cmd.SetArgs([]string{})
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+
+	err := cmd.Execute()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no bot or user token authenticated")
 }
 
 func TestRunMe_BotWithoutBotID(t *testing.T) {

--- a/internal/cmd/me/me_test.go
+++ b/internal/cmd/me/me_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestRunMe_BotTokenOnly(t *testing.T) {
+	testutil.Setup(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/auth.test", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
@@ -31,12 +33,14 @@ func TestRunMe_BotTokenOnly(t *testing.T) {
 	botClient := client.NewWithConfig(server.URL, "xoxb-test", nil)
 	opts := &meOptions{}
 
-	// Pass bot client, nil for user client
+	// Pass bot client, nil for user client (hermetic — no real user token can leak in)
 	err := runMe(opts, botClient, nil)
 	require.NoError(t, err)
 }
 
 func TestRunMe_UserTokenOnly(t *testing.T) {
+	testutil.Setup(t)
+
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/auth.test", r.URL.Path)
 		w.Header().Set("Content-Type", "application/json")
@@ -53,9 +57,31 @@ func TestRunMe_UserTokenOnly(t *testing.T) {
 	userClient := client.NewWithConfig(server.URL, "xoxp-test", nil)
 	opts := &meOptions{}
 
-	// Pass nil for bot client, user client provided
+	// Pass nil for bot client (hermetic — no real bot token can leak in), user client provided
 	err := runMe(opts, nil, userClient)
 	require.NoError(t, err)
+}
+
+func TestRunMe_UserAuthFailedBotNil(t *testing.T) {
+	// Symmetric to TestRunMe_AuthFailed: user token returns invalid_auth,
+	// bot client is nil with a hermetic empty keyring.
+	testutil.Setup(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":    false,
+			"error": "invalid_auth",
+		})
+	}))
+	defer server.Close()
+
+	userClient := client.NewWithConfig(server.URL, "bad-user-token", nil)
+	opts := &meOptions{}
+
+	err := runMe(opts, nil, userClient)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no bot or user token authenticated")
 }
 
 func TestRunMe_BothTokens(t *testing.T) {

--- a/internal/cmd/me/me_test.go
+++ b/internal/cmd/me/me_test.go
@@ -151,6 +151,30 @@ func TestRunMe_AuthFailed(t *testing.T) {
 	assert.Contains(t, err.Error(), "no bot or user token authenticated")
 }
 
+func TestRunMe_BothClientsAuthFailed(t *testing.T) {
+	// Both clients are non-nil and both auth.test calls return invalid_auth.
+	// Distinct from the *_BotNil / *_AuthFailed variants — exercises the
+	// path through both AuthTest calls before the both-nil check.
+	testutil.Setup(t)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"ok":    false,
+			"error": "invalid_auth",
+		})
+	}))
+	defer server.Close()
+
+	botClient := client.NewWithConfig(server.URL, "bad-bot-token", nil)
+	userClient := client.NewWithConfig(server.URL, "bad-user-token", nil)
+	opts := &meOptions{}
+
+	err := runMe(opts, botClient, userClient)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no bot or user token authenticated")
+}
+
 func TestNewCmd_NoTokens_ReturnsError(t *testing.T) {
 	testutil.Setup(t)
 


### PR DESCRIPTION
## Summary
- When `runMe` finds both bot and user tokens missing/invalid, return an error instead of printing a message and `return nil`.
- The cobra `RunE` now propagates this to a non-zero exit, satisfying the cli-common scriptability §3.1 health-check contract.
- Happy path (at least one token authenticates) is unchanged.

## Test plan
- [x] Unit tests: `go test ./internal/cmd/me/...` — 7 tests green (2 flipped to assert error, 1 new boundary test at the cobra `Execute()` layer).
- [x] `TestRunMe_AuthFailed` gained `testutil.Setup(t)` so the nil userClient path no longer reaches the real keyring.
- [x] Lint: `make lint` — 0 issues.
- [x] Build: `make build` — `bin/slck` produced.
- [ ] Manual happy path: `slck me; echo \$?` → bot/user/workspace lines, exit 0.
- [ ] Manual failure path: clear tokens → `slck me; echo \$?` → stderr error \"no bot or user token authenticated; run 'slck init' to configure authentication\", exit non-zero.

## Breaking-change note
Any script that today assumed `slck me` always exits 0 will break. That script is *wrong* per the §3.1 contract — fixing it is the point of the change.

Closes #172