### PR TITLE
chore: align darwin codesign hook to the fail-loud form

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -48,7 +48,7 @@ builds:
     # local builds → signing skipped.
     hooks:
       post:
-        - cmd: bash -c 'f="${CODESIGN_DARWIN_SCRIPT:-}"; [ -n "$f" ] && [ -x "$f" ] && exec "$f" "$0" "$1"; echo "skip codesign (no CODESIGN_DARWIN_SCRIPT)"' "{{ .Path }}" "{{ .Os }}"
+        - cmd: bash -c 'f="${CODESIGN_DARWIN_SCRIPT:-}"; if [ -z "$f" ]; then echo "skip codesign (CODESIGN_DARWIN_SCRIPT unset, local build)"; exit 0; fi; [ -x "$f" ] || { echo "CODESIGN_DARWIN_SCRIPT not executable ($f)" >&2; exit 1; }; exec "$f" "$0" "$1"' "{{ .Path }}" "{{ .Os }}"
   - id: slck-unix-win
     main: ./cmd/slck
     binary: slck


### PR DESCRIPTION
slck carried the original *simple* darwin codesign hook; the other five family CLIs (cfl/jtk/gro/nrq/cr) ship the hardened *fail-loud* form — where `CODESIGN_DARWIN_SCRIPT` set-but-missing or non-executable **errors** instead of silently skipping. This makes slck's hook byte-identical to theirs so the convention (cli-common `distribution.md §2A`) is uniform across all six repos.

- YAML-only; `.goreleaser.yaml` is not a gated release path → no release is cut.
- `goreleaser check -f .goreleaser.yaml` passes.
- Verified byte-identical to the cfl hook.